### PR TITLE
Remove debug output and add basic logger

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -1,5 +1,6 @@
 import User from '../models/User.js';
 import jwt from 'jsonwebtoken';
+import { log } from '../utils/logger.js';
 
 const JWT_SECRET = process.env.JWT_SECRET || 'yoursecretkey';
 const REFRESH_SECRET = process.env.REFRESH_SECRET || 'refreshsecretkey';
@@ -30,7 +31,7 @@ export const registerUser = async (req, res) => {
 
     res.status(201).json({ message: 'User registered successfully' });
   } catch (err) {
-    console.error("❌ REGISTER ERROR:", err); // Add this
+    log('REGISTER ERROR:', err);
     res.status(500).json({ message: 'Server error', error: err.message });
   }
 };
@@ -38,7 +39,6 @@ export const registerUser = async (req, res) => {
 export const loginUser = async (req, res) => {
   try {
     const { email, password } = req.body;
-    console.log("Login body:", req.body);
     
 
     if (!email || !password) {

--- a/backend/controllers/jarvisController.js
+++ b/backend/controllers/jarvisController.js
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { env } from "../config/env.js";
 import { refreshSchwabToken } from "../config/schwab.js";
+import { log } from "../utils/logger.js";
 
 const STOCKBOT_URL = env.STOCKBOT_URL;
 
@@ -10,8 +11,7 @@ let voiceProcess = null;
 // ---- TEXT PROMPT → LLM ----
 export const handleJarvisPrompt = async (req, res) => {
   const { prompt, model, format } = req.body;
-  console.log("Body:", { prompt, model, format });
-  console.log("User:", req.user);
+  log("Jarvis prompt:", { prompt, model, format });
 
   if (!prompt || !model || !format) {
     return res.status(400).json({ error: "Missing required fields." });

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -53,9 +53,6 @@ userSchema.pre('save', async function (next) {
 // Method to compare passwords
 userSchema.methods.matchPassword = async function (enteredPassword) {
   const match = await bcrypt.compare(enteredPassword, this.password);
-  console.log("Entered Password:", enteredPassword);
-  console.log("Stored Hashed Password:", this.password);
-  console.log("Match Result:", match);
   return match;
 };
 

--- a/backend/utils/logger.js
+++ b/backend/utils/logger.js
@@ -1,0 +1,11 @@
+const isProd = process.env.NODE_ENV === 'production';
+
+export const log = (...args) => {
+  if (!isProd) {
+    console.log(...args);
+  }
+};
+
+export const error = (...args) => {
+  console.error(...args);
+};


### PR DESCRIPTION
## Summary
- add simple logger utility for backend
- remove noisy console logs from auth and jarvis controllers
- strip password debug logs from User model

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_688420f9f2d88331806535d4c1cac50e