### PR TITLE
Improve backend route organization

### DIFF
--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,0 +1,14 @@
+import express from 'express';
+import authRoutes from './authRoutes.js';
+import userRoutes from './userRoutes.js';
+import jarvisRoutes from './jarvisRoutes.js';
+import schwabRoutes from './schwabRoutes.js';
+
+const router = express.Router();
+
+router.use('/auth', authRoutes);
+router.use('/users', userRoutes);
+router.use('/jarvis', jarvisRoutes);
+router.use('/schwab', schwabRoutes);
+
+export default router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,15 +3,13 @@ import { env } from './config/env.js';
 import cors from 'cors';
 import corsOptions from './config/corsOptions.js';
 import connectDB from './config/db.js';
-import authRoutes from './routes/authRoutes.js';
-import userRoutes from './routes/userRoutes.js';
 import cookieParser from 'cookie-parser';
-import jarvisRoutes from './routes/jarvisRoutes.js';
-import schwabRoutes from './routes/schwabRoutes.js';
+import apiRoutes from './routes/index.js';
 
 
 connectDB();
 const app = express();
+const API_VERSION = 'v1';
 app.use(cors(corsOptions));
 app.use(cookieParser());
 app.use(express.json());
@@ -26,10 +24,7 @@ app.get('/', (req, res) => {
 
 
 // Routes
-app.use('/api/auth', authRoutes);
-app.use('/api/users', userRoutes);
-app.use("/api/jarvis", jarvisRoutes);
-app.use('/api/schwab', schwabRoutes);
+app.use(`/api/${API_VERSION}`, apiRoutes);
 
 // Server
 const PORT = env.PORT || 5000;


### PR DESCRIPTION
## Summary
- centralize Express routers under a new `routes/index.js`
- version API entrypoint and mount aggregated routes

## Testing
- `node backend/server.js` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68842468fbd48331b5dcd820a0e9f5d5