### PR TITLE
docs: add project setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Stock Bot Web Application
+
+A full-stack platform for interacting with an automated stock-trading bot. The project is composed of three parts:
+
+- **Frontend** – Next.js interface for users.
+- **Backend** – Node/Express API layer.
+- **Stock Bot** – Python service that runs trading logic.
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) and npm
+- [Python 3](https://www.python.org/)
+- [Infisical CLI](https://infisical.com/docs/cli) for managing secrets
+
+## Getting Started
+
+Clone the repository and set up each component.
+
+### Backend
+
+```bash
+cd backend
+infisical init
+npm install
+npm run dev
+```
+
+### Frontend
+
+```bash
+cd frontend
+infisical init
+npm install
+npm run dev
+```
+
+### Stock Bot Server
+
+```bash
+cd stockbot
+setup_venv.bat   # run once to set up the virtual environment
+run_dev.bat       # start the bot server
+```
+
+> On non-Windows systems, run the equivalent shell scripts if provided or execute the Python modules directly.
+
+## Project Structure
+
+```text
+backend/   - Express API server
+frontend/  - Next.js web client
+stockbot/  - Python trading bot service
+```
+
+## License
+
+This project is provided as-is without warranty. See individual directories for more details.
+


### PR DESCRIPTION
## Summary
- add root README with prerequisites and setup steps for frontend, backend, and stock bot services

## Testing
- `cd backend && npm test` *(fails: Missing script: "test")*
- `cd frontend && npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_688d7e20c10083318f516749b970596c