### PR TITLE
feat: add macOS command scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The project consists of three interconnected services:
 
 ## 🚀 Quick Start
 
+> **Note:** Use `.bat` scripts on Windows and `.command` scripts on macOS.
+
 ### 1. Clone and Initial Setup
 ```bash
 git clone https://github.com/BilliamsFluster/StockBotWebApp.git
@@ -64,10 +66,13 @@ curl -1sLf 'https://dl.cloudsmith.io/public/infisical/infisical-cli/setup.deb.sh
 sudo apt-get update && sudo apt-get install infisical
 ```
 
-### 3. Automated Setup (Windows)
+### 3. Automated Setup
 ```bash
-# Starts all three services automatically
+# Windows
 start-dev-all.bat
+
+# macOS
+./start-dev-all.command
 ```
 
 ### 4. Manual Setup (All Platforms)
@@ -93,10 +98,14 @@ npm run dev     # Starts on https://localhost:3000
 cd stockbot
 
 # Windows
-setup_venv.bat  # One-time setup
-run_dev.bat     # Start the service
+setup_venv.bat      # One-time setup
+run_dev.bat         # Start the service
 
-# macOS/Linux
+# macOS
+./setup_venv.command  # One-time setup
+./run_dev.command     # Start the service
+
+# Linux
 python -m venv venv
 source venv/bin/activate  # or `venv/bin/activate.fish` for fish shell
 pip install --upgrade pip
@@ -236,8 +245,9 @@ cd backend && npm run dev
 cd frontend && npm run dev
 
 # StockBot only
-cd stockbot && run_dev.bat  # Windows
-cd stockbot && source venv/bin/activate && uvicorn server:app --reload --host 0.0.0.0 --port 5002  # macOS/Linux
+cd stockbot && run_dev.bat         # Windows
+cd stockbot && ./run_dev.command   # macOS
+cd stockbot && source venv/bin/activate && uvicorn server:app --reload --host 0.0.0.0 --port 5002  # Linux
 ```
 
 ### Database Setup
@@ -279,8 +289,8 @@ cd stockbot && python -m pytest
 
 **Port Conflicts**
 - Backend: Change `BACKEND_PORT` in Infisical
-- Frontend: Change `FRONTEND_PORT` in Infisical  
-- StockBot: Modify port in `run_dev.bat` or startup command
+- Frontend: Change `FRONTEND_PORT` in Infisical
+- StockBot: Modify port in `run_dev.bat`/`run_dev.command` or startup command
 
 **SSL Certificate Issues**
 ```bash
@@ -297,8 +307,9 @@ mv localhost+2-key.pem cert.key
 # Clear and reinstall
 cd stockbot
 rm -rf venv
-setup_venv.bat  # Windows
-# or manual setup for macOS/Linux
+setup_venv.bat        # Windows
+./setup_venv.command  # macOS
+# or manual setup for Linux
 ```
 
 **Database Connection**

--- a/start-dev-all.command
+++ b/start-dev-all.command
@@ -1,0 +1,26 @@
+#!/bin/bash
+# capture the root of this script
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+
+# ───────────── Backend ─────────────
+osascript <<OSA
+  tell application "Terminal"
+    do script "cd \"$ROOT/backend\" && npm run dev"
+  end tell
+OSA
+
+# ───────────── Frontend ────────────
+osascript <<OSA
+  tell application "Terminal"
+    do script "cd \"$ROOT/frontend\" && npm run dev"
+  end tell
+OSA
+
+# ───────────── StockBot ────────────
+osascript <<OSA
+  tell application "Terminal"
+    do script "cd \"$ROOT/stockbot\" && ./run_dev.command"
+  end tell
+OSA
+
+exit 0

--- a/stockbot/run_dev.command
+++ b/stockbot/run_dev.command
@@ -1,0 +1,4 @@
+#!/bin/bash
+DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$DIR/venv/bin/activate"
+uvicorn server:app --reload --host 0.0.0.0 --port 5002

--- a/stockbot/setup_venv.command
+++ b/stockbot/setup_venv.command
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+VENV_DIR="$DIR/venv"
+PYTHON_PATH="$VENV_DIR/bin/python"
+
+# Step 1: Create virtual environment if it doesn't exist
+if [ ! -f "$PYTHON_PATH" ]; then
+  echo "🔧 Creating virtual environment..."
+  python3 -m venv "$VENV_DIR"
+fi
+
+# Step 2: Upgrade pip and install requirements
+echo "🛠 Activating virtual environment and installing dependencies..."
+source "$VENV_DIR/bin/activate"
+
+echo "🚀 Upgrading pip..."
+"$PYTHON_PATH" -m pip install --upgrade pip
+
+echo "📦 Installing from requirements.txt..."
+"$PYTHON_PATH" -m pip install -r "$DIR/requirements.txt"
+
+echo
+
+echo "✅ Virtual environment setup complete."


### PR DESCRIPTION
## Summary
- add `.command` macOS launchers for root, StockBot dev, and virtualenv setup
- document platform-specific startup scripts in README

## Testing
- `cmd /c start-dev-all.bat` *(fails: command not found)*
- `cmd /c stockbot/run_dev.bat` *(fails: command not found)*
- `cmd /c stockbot/setup_venv.bat` *(fails: command not found)*
- `bash start-dev-all.command` *(fails: osascript: command not found)*
- `bash stockbot/run_dev.command` *(fails: venv/uvicorn not found)*
- `bash stockbot/setup_venv.command` *(fails: pip install requirements)*

------
https://chatgpt.com/codex/tasks/task_e_6895255a7828833190c92de55dd6f849