### PR TITLE
Improve Stockbot file upload/download paths

### DIFF
--- a/backend/controllers/stockbotController.js
+++ b/backend/controllers/stockbotController.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import FormData from "form-data";
 
 const STOCKBOT_URL = process.env.STOCKBOT_URL;
 
@@ -20,6 +21,9 @@ export async function startTrainProxy(req, res) {
     return res.status(400).json({ error: errMsg(e) });
   }
 }
+
+
+
 
 /** POST /api/stockbot/backtest */
 export async function startBacktestProxy(req, res) {
@@ -44,7 +48,9 @@ export async function listRunsProxy(_req, res) {
 /** GET /api/stockbot/runs/:id */
 export async function getRunProxy(req, res) {
   try {
-    const { data } = await axios.get(`${STOCKBOT_URL}/api/stockbot/runs/${req.params.id}`);
+    const { data } = await axios.get(
+      `${STOCKBOT_URL}/api/stockbot/runs/${encodeURIComponent(req.params.id)}`
+    );
     return res.json(data);
   } catch (e) {
     return res.status(400).json({ error: errMsg(e) });
@@ -54,7 +60,9 @@ export async function getRunProxy(req, res) {
 /** GET /api/stockbot/runs/:id/artifacts */
 export async function getRunArtifactsProxy(req, res) {
   try {
-    const { data } = await axios.get(`${STOCKBOT_URL}/api/stockbot/runs/${req.params.id}/artifacts`);
+    const { data } = await axios.get(
+      `${STOCKBOT_URL}/api/stockbot/runs/${encodeURIComponent(req.params.id)}/artifacts`
+    );
     return res.json(data);
   } catch (e) {
     return res.status(400).json({ error: errMsg(e) });
@@ -64,7 +72,9 @@ export async function getRunArtifactsProxy(req, res) {
 /** GET /api/stockbot/runs/:id/files/:name -> stream file */
 export async function getRunArtifactFileProxy(req, res) {
   try {
-    const url = `${STOCKBOT_URL}/api/stockbot/runs/${req.params.id}/files/${req.params.name}`;
+    const url = `${STOCKBOT_URL}/api/stockbot/runs/${encodeURIComponent(
+      req.params.id
+    )}/files/${encodeURIComponent(req.params.name)}`;
     const resp = await axios.get(url, { responseType: "stream" });
     if (resp.headers["content-type"]) res.setHeader("content-type", resp.headers["content-type"]);
     if (resp.headers["content-disposition"]) res.setHeader("content-disposition", resp.headers["content-disposition"]);
@@ -75,6 +85,22 @@ export async function getRunArtifactFileProxy(req, res) {
 }
 
 /** GET /api/stockbot/runs/:id/bundle -> stream zip */
+export async function getRunBundleProxy(req, res) {
+  try {
+    const url = `${STOCKBOT_URL}/api/stockbot/runs/${encodeURIComponent(
+      req.params.id
+    )}/bundle`;
+    const resp = await axios.get(url, {
+      responseType: "stream",
+      params: req.query,
+    });
+    if (resp.headers["content-type"]) res.setHeader("content-type", resp.headers["content-type"]);
+    if (resp.headers["content-disposition"]) res.setHeader("content-disposition", resp.headers["content-disposition"]);
+    resp.data.pipe(res);
+  } catch (e) {
+    return res.status(400).json({ error: errMsg(e) });
+  }
+}
 
 
 export async function uploadPolicyProxy(req, res) {

--- a/backend/routes/stockbotRoutes.js
+++ b/backend/routes/stockbotRoutes.js
@@ -8,7 +8,8 @@ import {
   getRunProxy,
   uploadPolicyProxy,
   getRunArtifactsProxy,
-  getRunArtifactFileProxy, 
+  getRunArtifactFileProxy,
+  getRunBundleProxy,
 } from "../controllers/stockbotController.js";
 import { protectRoute } from "../middleware/protectRoute.js";
 
@@ -28,8 +29,10 @@ router.get("/runs/:id/artifacts", protectRoute, getRunArtifactsProxy);
 
 // Stream a specific artifact (metrics, equity, trades, orders, summary, config, model, job_log)
 router.get("/runs/:id/files/:name", protectRoute, getRunArtifactFileProxy);
+router.get("/runs/:id/bundle", protectRoute, getRunBundleProxy);
 
 router.post("/policies/upload", protectRoute, upload.single("file"), uploadPolicyProxy);
 
 
 export default router;
+

--- a/frontend/src/api/stockbot.ts
+++ b/frontend/src/api/stockbot.ts
@@ -1,0 +1,34 @@
+import axios from "axios";
+
+const BASE = process.env.NEXT_PUBLIC_BACKEND_URL;
+
+const join = (base: string | undefined | null, path: string) => {
+  const b = (base ?? "").replace(/\/+$/, "");
+  const p = (path ?? "").replace(/^\/+/, "");
+  return b ? `${b}/${p}` : `/${p}`;
+};
+
+const buildUrl = (u: string) =>
+  /^https?:\/\//i.test(u) || /^\/\//.test(u) ? u : BASE ? join(BASE, u) : u;
+
+export async function uploadPolicy(file: File) {
+  const form = new FormData();
+  form.append("file", file);
+  const { data } = await axios.post(buildUrl("/api/stockbot/policies/upload"), form, {
+    withCredentials: true,
+  });
+  return data as { policy_path: string };
+}
+
+export async function downloadRunBundle(runId: string, includeModel = true): Promise<Blob> {
+  const { data } = await axios.get(
+    buildUrl(`/api/stockbot/runs/${encodeURIComponent(runId)}/bundle`),
+    {
+      withCredentials: true,
+      responseType: "blob",
+      params: { include_model: includeModel },
+    }
+  );
+  return data as Blob;
+}
+


### PR DESCRIPTION
## Summary
- Securely encode run IDs and artifact names when proxying Stockbot files
- Support downloading run bundles via backend proxy
- Add frontend helpers for policy uploads and run bundle downloads

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm test` (frontend) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6837e4f488331a17c9a18634baed6