### PR TITLE
Refactor Stockbot dashboard and backtest flow

### DIFF
--- a/frontend/src/app/stockbot/page.tsx
+++ b/frontend/src/app/stockbot/page.tsx
@@ -12,6 +12,7 @@ import Settings from "@/components/Stockbot/Settings";
 
 export default function Page() {
   const [tab, setTab] = useState("dashboard");
+  const [backtestRunId, setBacktestRunId] = useState<string | null>(null);
 
   return (
     <div className="p-6 space-y-6">
@@ -28,10 +29,16 @@ export default function Page() {
         <TabsContent value="dashboard">
           <Dashboard
             onNewTraining={() => setTab("new-training")}
-            onNewBacktest={() => setTab("new-backtest")}
-            // Keep the signature but ignore the id since RunDetail is upload-only now
+            onNewBacktest={() => {
+              setBacktestRunId(null);
+              setTab("new-backtest");
+            }}
             onOpenRun={(_id) => {
               setTab("run-detail");
+            }}
+            onBacktestRun={(id) => {
+              setBacktestRunId(id);
+              setTab("new-backtest");
             }}
           />
         </TabsContent>
@@ -48,6 +55,7 @@ export default function Page() {
 
         <TabsContent value="new-backtest">
           <NewBacktest
+            runId={backtestRunId ?? undefined}
             onJobCreated={(_id) => {
               setTab("run-detail");
             }}

--- a/frontend/src/components/Stockbot/NewTraining.tsx
+++ b/frontend/src/components/Stockbot/NewTraining.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { fetchJSON, postJSON } from "./lib/api";
+import { addRecentRun } from "./lib/runs";
 import type { JobStatusResponse, RunArtifacts } from "./lib/types";
 
 type TrainPayload = {
@@ -153,6 +154,7 @@ export default function NewTraining({
       setProgress("Job started. Polling status…");
 
       // Optionally jump to Run Detail tab immediately:
+      addRecentRun({ id: resp.job_id, type: "train", status: "QUEUED", created_at: new Date().toISOString() });
       onJobCreated(resp.job_id);
     } catch (e: any) {
       setError(e?.message ?? String(e));

--- a/frontend/src/components/Stockbot/lib/runs.ts
+++ b/frontend/src/components/Stockbot/lib/runs.ts
@@ -1,0 +1,55 @@
+import { RunSummary } from "./types";
+
+const RECENT_KEY = "stockbot_recent_runs";
+const SAVED_KEY = "stockbot_saved_runs";
+const MAX_RECENT = 5;
+const MAX_SAVED = 5;
+
+type StoreKey = typeof RECENT_KEY | typeof SAVED_KEY;
+
+function load(key: StoreKey): RunSummary[] {
+  if (typeof localStorage === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as RunSummary[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function save(key: StoreKey, runs: RunSummary[], max: number): RunSummary[] {
+  const uniq = runs.filter((r, i, arr) => arr.findIndex((x) => x.id === r.id) === i);
+  const capped = uniq.slice(0, max);
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem(key, JSON.stringify(capped));
+  }
+  return capped;
+}
+
+export function loadRecentRuns(): RunSummary[] {
+  return load(RECENT_KEY);
+}
+
+export function saveRecentRuns(runs: RunSummary[]): RunSummary[] {
+  return save(RECENT_KEY, runs, MAX_RECENT);
+}
+
+export function addRecentRun(run: RunSummary): RunSummary[] {
+  const next = [run, ...loadRecentRuns()];
+  return saveRecentRuns(next);
+}
+
+export function loadSavedRuns(): RunSummary[] {
+  return load(SAVED_KEY);
+}
+
+export function saveSavedRuns(runs: RunSummary[]): RunSummary[] {
+  return save(SAVED_KEY, runs, MAX_SAVED);
+}
+
+export function toggleSavedRun(run: RunSummary): RunSummary[] {
+  const current = loadSavedRuns();
+  const exists = current.find((r) => r.id === run.id);
+  const next = exists ? current.filter((r) => r.id !== run.id) : [run, ...current];
+  return saveSavedRuns(next);
+}


### PR DESCRIPTION
## Summary
- store up to five recent and saved runs on the client
- allow selecting a run for backtesting without uploading a model
- support run-based backtests in the StockBot API

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a74729398083318fbbf4553ea7e4cb