### PR TITLE
Normalize portfolio data across brokers for portfolio UI

### DIFF
--- a/frontend/src/components/Portfolio/HoldingPieChart.tsx
+++ b/frontend/src/components/Portfolio/HoldingPieChart.tsx
@@ -18,26 +18,21 @@ import {
 
 const COLORS = ['#818cf8', '#4ade80', '#facc15', '#fb7185', '#38bdf8', '#a78bfa'];
 
+import { Position } from "@/types/portfolio";
+
 type Props = {
   summary: { equity: number };
-  positions: {
-    symbol: string;
-    marketValue?: number;
-    value?: number;
-  }[];
+  positions: Position[];
 };
 
 const HoldingPieChart: React.FC<Props> = ({ summary, positions }) => {
   const totalEquity = summary?.equity || 0;
 
-  let chartData = positions.map((pos) => {
-    const marketValue = pos.marketValue ?? pos.value ?? 0;
-    return {
-      symbol: pos.symbol,
-      value: marketValue,
-      percent: totalEquity > 0 ? (marketValue / totalEquity) * 100 : 0,
-    };
-  });
+  let chartData = positions.map((pos) => ({
+    symbol: pos.symbol,
+    value: pos.marketValue,
+    percent: totalEquity > 0 ? (pos.marketValue / totalEquity) * 100 : 0,
+  }));
 
   const investedTotal = chartData.reduce((sum, p) => sum + p.value, 0);
   const cashValue = totalEquity - investedTotal;

--- a/frontend/src/components/Portfolio/PortfolioPage.tsx
+++ b/frontend/src/components/Portfolio/PortfolioPage.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { useEffect, useMemo, useState } from "react";
 import { usePortfolioData } from "@/hooks/usePortfolioData";
 import { getUserPreferences } from "@/api/client";
+import type { Position, Transaction } from "@/types/portfolio";
 
 /** shadcn/ui */
 import {
@@ -78,8 +79,8 @@ export default function PortfolioPage() {
   const [checkingBroker, setCheckingBroker] = useState(true);
 
   const summary: Summary = data?.portfolio?.summary ?? DEFAULT_SUMMARY;
-  const positions = data?.portfolio?.positions ?? [];
-  const transactions = data?.portfolio?.transactions ?? [];
+  const positions: Position[] = data?.portfolio?.positions ?? [];
+  const transactions: Transaction[] = data?.portfolio?.transactions ?? [];
 
   /** Check active broker once */
   useEffect(() => {

--- a/frontend/src/components/Portfolio/PositionTable.tsx
+++ b/frontend/src/components/Portfolio/PositionTable.tsx
@@ -9,16 +9,7 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-
-// --- Type Definition ---
-export type Position = {
-  symbol: string;
-  qty: number;
-  price: number;   // may be undefined at runtime from API; we'll guard below
-  value: number;
-  dayPL: number;
-  totalPL: number;
-};
+import { Position } from "@/types/portfolio";
 
 // --- Format helpers ---
 const fmtCurrency = (n?: number | null) =>
@@ -99,7 +90,7 @@ const PositionTable: React.FC<PositionTableProps> = ({ positions }) => {
             <TableCell className="font-medium">{pos.symbol}</TableCell>
             <TableCell className="text-right">{fmtNumber(pos.qty, 0)}</TableCell>
             <TableCell className="text-right">{fmtNumber(pos.price, 2)}</TableCell>
-            <TableCell className="text-right">{fmtCurrency(pos.value)}</TableCell>
+            <TableCell className="text-right">{fmtCurrency(pos.marketValue)}</TableCell>
             <PnLCell value={pos.dayPL} />
             <PnLCell value={pos.totalPL} />
           </TableRow>

--- a/frontend/src/components/Portfolio/TradingHistoryTable.tsx
+++ b/frontend/src/components/Portfolio/TradingHistoryTable.tsx
@@ -15,8 +15,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-
-type SchwabTransaction = any;
+import { Transaction } from "@/types/portfolio";
 
 type Trade = {
   id: string | number;
@@ -29,37 +28,25 @@ type Trade = {
 };
 
 type Props = {
-  transactions: SchwabTransaction[];
+  transactions: Transaction[];
 };
 
 const TradingHistoryTable: React.FC<Props> = ({ transactions }) => {
   const trades: Trade[] = useMemo(() => {
-    if (!Array.isArray(transactions)) return [];
-
     return transactions
       .filter((tx) => tx.type === 'TRADE')
-      .map((tx, index) => {
-        const transfer = tx?.transferItems?.find(
-          (item: any) => item?.instrument?.assetType === 'EQUITY'
-        );
-
-        const symbol = transfer?.instrument?.symbol ?? '—';
-        const quantity = transfer?.amount ?? 0;
-        const amount = tx.netAmount ?? 0;
-        const action: Trade['action'] = amount < 0 ? 'BUY' : 'SELL';
-        const price = transfer?.price ?? undefined;
-
+      .map((tx) => {
+        const action: Trade['action'] = tx.amount < 0 ? 'BUY' : 'SELL';
         return {
-          id: tx.activityId ?? index,
-          date: tx.tradeDate || tx.time || new Date().toISOString(),
-          symbol,
+          id: tx.id,
+          date: tx.date,
+          symbol: tx.symbol,
           action,
-          quantity: Math.abs(quantity),
-          amount: Math.abs(amount),
-          price,
+          quantity: Math.abs(tx.quantity),
+          amount: Math.abs(tx.amount),
+          price: tx.price,
         };
-      })
-      .filter((trade) => trade.symbol !== '—');
+      });
   }, [transactions]);
 
   if (trades.length === 0) {

--- a/frontend/src/components/Portfolio/TransactionsTable.tsx
+++ b/frontend/src/components/Portfolio/TransactionsTable.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import {
   Table,
   TableBody,
@@ -16,38 +16,14 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-
-export type Transaction = {
-  id: string | number;
-  date: string | Date;
-  symbol: string;
-  type: string;
-  quantity: number;
-  amount: number;
-};
-
-type SchwabTransaction = any; // Replace with stricter typing if needed
+import { Transaction } from "@/types/portfolio";
 
 type Props = {
-  transactions: SchwabTransaction[]; // Accepts raw Schwab format
+  transactions: Transaction[];
 };
 
 const TransactionsTable: React.FC<Props> = ({ transactions }) => {
-  const parsedTransactions: Transaction[] = useMemo(() => {
-    if (!Array.isArray(transactions)) return [];
-
-    return transactions.map((tx, index) => ({
-      id: tx.activityId ?? index,
-      date: tx.tradeDate || tx.time || new Date().toISOString(),
-      symbol:
-        tx?.transferItems?.[0]?.instrument?.symbol?.replace('CURRENCY_', '') ?? 'N/A',
-      type: tx.type ?? 'UNKNOWN',
-      quantity: Number(tx?.transferItems?.[0]?.amount ?? 0), // ✅ Ensure numeric
-      amount: Number(tx.netAmount ?? 0), // ✅ Ensure numeric
-    }));
-  }, [transactions]);
-
-  if (parsedTransactions.length === 0) {
+  if (!transactions.length) {
     return (
       <div className="rounded-xl backdrop-blur-lg bg-black/20 p-4 shadow-xl border border-purple-400/20">
         <h2 className="text-sm font-semibold text-white mb-2">Recent Transactions</h2>
@@ -72,7 +48,7 @@ const TransactionsTable: React.FC<Props> = ({ transactions }) => {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {parsedTransactions.slice(0, 5).map((tx) => (
+            {transactions.slice(0, 5).map((tx) => (
               <TableRow key={tx.id}>
                 <TableCell>{new Date(tx.date).toLocaleDateString()}</TableCell>
                 <TableCell>

--- a/frontend/src/types/portfolio.ts
+++ b/frontend/src/types/portfolio.ts
@@ -1,0 +1,18 @@
+export type Position = {
+  symbol: string;
+  qty: number;
+  price: number;
+  marketValue: number;
+  dayPL: number;
+  totalPL: number;
+};
+
+export type Transaction = {
+  id: string | number;
+  date: string;
+  symbol: string;
+  type: string;
+  quantity: number;
+  amount: number;
+  price?: number;
+};

--- a/stockbot/providers/alpaca_provider.py
+++ b/stockbot/providers/alpaca_provider.py
@@ -120,7 +120,7 @@ class AlpacaProvider(BaseProvider):
         Matches the structure expected by the frontend.
         """
         account = self.get_account()
-        positions = self.get_positions()
+        raw_positions = self.get_positions()
 
         summary = {
             "accountNumber": account.get("account_number", "—"),
@@ -131,8 +131,23 @@ class AlpacaProvider(BaseProvider):
             "dayTradingBuyingPower": float(account.get("daytrading_buying_power", 0)),
         }
 
+        # ✅ Normalize positions to a common structure for the frontend
+        positions = []
+        for pos in raw_positions:
+            try:
+                positions.append({
+                    "symbol": pos.get("symbol", ""),
+                    "qty": float(pos.get("qty", 0)),
+                    "price": float(pos.get("avg_entry_price", 0)),
+                    "marketValue": float(pos.get("market_value", 0)),
+                    "dayPL": float(pos.get("unrealized_intraday_pl", 0)),
+                    "totalPL": float(pos.get("unrealized_pl", 0)),
+                })
+            except Exception:
+                continue
+
         return {
             "summary": summary,
             "positions": positions,
-            "transactions": []  # Can integrate Alpaca transactions later
+            "transactions": []  # Alpaca transactions not integrated yet
         }

--- a/stockbot/providers/schwab_provider.py
+++ b/stockbot/providers/schwab_provider.py
@@ -153,13 +153,63 @@ class SchwabProvider(BaseProvider):
     def get_portfolio_data(self) -> Dict[str, Any]:
         """Returns a consistent portfolio structure for stockbot."""
         summary = self.get_account_summary()
-        positions = self.get_positions()
+        raw_positions = self.get_positions()
         try:
-            transactions = self.get_transactions()
+            raw_transactions = self.get_transactions()
         except Exception:
-            transactions = []
+            raw_transactions = []
+
+        # ✅ Normalize positions
+        positions = []
+        for pos in raw_positions:
+            instrument = pos.get("instrument", {})
+            symbol = instrument.get("symbol", "")
+            qty = float(pos.get("longQuantity", 0)) - float(pos.get("shortQuantity", 0))
+            price = (
+                pos.get("averagePrice")
+                or pos.get("averageLongPrice")
+                or pos.get("averageShortPrice")
+                or 0
+            )
+            try:
+                positions.append({
+                    "symbol": symbol,
+                    "qty": float(qty),
+                    "price": float(price),
+                    "marketValue": float(pos.get("marketValue", 0)),
+                    "dayPL": float(pos.get("currentDayProfitLoss", 0)),
+                    "totalPL": float(
+                        pos.get("longOpenProfitLoss", 0)
+                        or pos.get("shortOpenProfitLoss", 0)
+                    ),
+                })
+            except Exception:
+                continue
+
+        # ✅ Normalize transactions
+        transactions = []
+        for tx in raw_transactions:
+            transfer_items = tx.get("transferItems", [])
+            first = transfer_items[0] if transfer_items else {}
+            instrument = first.get("instrument", {})
+            symbol = instrument.get("symbol", "").replace("CURRENCY_", "")
+            quantity = float(first.get("amount", 0))
+            price = first.get("price")
+            try:
+                transactions.append({
+                    "id": tx.get("activityId"),
+                    "date": tx.get("tradeDate") or tx.get("time"),
+                    "symbol": symbol,
+                    "type": tx.get("type"),
+                    "quantity": quantity,
+                    "amount": float(tx.get("netAmount", 0)),
+                    "price": price,
+                })
+            except Exception:
+                continue
+
         return {
             "summary": summary,
             "positions": positions,
-            "transactions": transactions
+            "transactions": transactions,
         }


### PR DESCRIPTION
## Summary
- Normalize Schwab and Alpaca provider portfolio data into shared Position and Transaction structures
- Add shared portfolio types and update portfolio components to consume normalized data
- Type-safe portfolio page setup to support broker-agnostic rendering

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d164ea04833183f3960df42c1248