### PR TITLE
Fix Schwab trade price parsing and history display

### DIFF
--- a/frontend/src/components/Portfolio/TradingHistoryTable.tsx
+++ b/frontend/src/components/Portfolio/TradingHistoryTable.tsx
@@ -87,7 +87,9 @@ const TradingHistoryTable: React.FC<Props> = ({ transactions }) => {
                   </Badge>
                 </TableCell>
                 <TableCell className="text-right">{trade.quantity}</TableCell>
-                <TableCell className="text-right">{trade.price !== undefined ? trade.price.toFixed(2) : '—'}</TableCell>
+                <TableCell className="text-right">
+                  {typeof trade.price === "number" ? trade.price.toFixed(2) : "—"}
+                </TableCell>
                 <TableCell className="text-right">{trade.amount.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}</TableCell>
               </TableRow>
             ))}


### PR DESCRIPTION
## Summary
- handle null trade prices in TradingHistoryTable
- parse Schwab transactions to select the security transfer item for price/quantity

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next: not found)
- `python -m pytest -q` (fails: no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68a8d32273708331aa130ef7caf8ca47