### PR TITLE
Enhance portfolio summary, holdings chart, and overview snapshot

### DIFF
--- a/frontend/src/components/Portfolio/HoldingPieChart.tsx
+++ b/frontend/src/components/Portfolio/HoldingPieChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React from 'react';
-import { Pie, PieChart } from "recharts";
+import { Pie, PieChart, Cell } from "recharts";
 import {
   Card,
   CardContent,
@@ -28,10 +28,12 @@ type Props = {
 const HoldingPieChart: React.FC<Props> = ({ summary, positions }) => {
   const totalEquity = summary?.equity || 0;
 
-  let chartData = positions.map((pos) => ({
+  // Map positions to chart data with color assignment
+  let chartData = positions.map((pos, idx) => ({
     symbol: pos.symbol,
     value: pos.marketValue,
     percent: totalEquity > 0 ? (pos.marketValue / totalEquity) * 100 : 0,
+    color: COLORS[idx % COLORS.length],
   }));
 
   const investedTotal = chartData.reduce((sum, p) => sum + p.value, 0);
@@ -42,6 +44,7 @@ const HoldingPieChart: React.FC<Props> = ({ summary, positions }) => {
       symbol: 'CASH',
       value: cashValue,
       percent: (cashValue / totalEquity) * 100,
+      color: COLORS[chartData.length % COLORS.length],
     });
   }
 
@@ -53,14 +56,13 @@ const HoldingPieChart: React.FC<Props> = ({ summary, positions }) => {
     );
   }
 
-  const chartConfig = {
-    value: { label: "Value" },
-    aapl: { label: "AAPL", color: "hsl(var(--chart-1))" },
-    nvda: { label: "NVDA", color: "hsl(var(--chart-2))" },
-    tsla: { label: "TSLA", color: "hsl(var(--chart-3))" },
-    msft: { label: "MSFT", color: "hsl(var(--chart-4))" },
-    other: { label: "Other", color: "hsl(var(--muted))" },
-  };
+  // Build chart config for legend & CSS variables
+  const chartConfig = Object.fromEntries(
+    chartData.map((d) => [
+      d.symbol.toLowerCase(),
+      { label: d.symbol, color: d.color },
+    ])
+  );
 
   return (
     <Card className="ink-card flex flex-col">
@@ -84,7 +86,14 @@ const HoldingPieChart: React.FC<Props> = ({ summary, positions }) => {
               nameKey="symbol"
               innerRadius={60}
               strokeWidth={5}
-            />
+            >
+              {chartData.map((entry) => (
+                <Cell
+                  key={entry.symbol}
+                  fill={`var(--color-${entry.symbol.toLowerCase()})`}
+                />
+              ))}
+            </Pie>
             <ChartLegend
               content={<ChartLegendContent nameKey="symbol" />}
               className="-translate-y-2 flex-wrap gap-2 [&>*]:basis-1/4 [&>*]:justify-center"

--- a/frontend/src/components/Portfolio/PortfolioSummaryCard.tsx
+++ b/frontend/src/components/Portfolio/PortfolioSummaryCard.tsx
@@ -37,21 +37,13 @@ interface PortfolioSummaryProps {
     liquidationValue: number;
     equity: number;
     cash: number;
+    buyingPower: number;
+    dayTradingBuyingPower?: number;
   };
   isLoading?: boolean;
 }
 
 const PortfolioSummaryCard: React.FC<PortfolioSummaryProps> = ({ summary, isLoading = false }) => {
-  // Mock data - replace with props
-  const data = {
-    netLiq: 127420,
-    dayPL: 1245,
-    ytdPL: 18920,
-    buyingPower: 232000,
-    beta: 1.45,
-    sharpe: 1.2,
-  };
-
   return (
     <Card className="ink-card">
       <CardHeader>
@@ -61,31 +53,37 @@ const PortfolioSummaryCard: React.FC<PortfolioSummaryProps> = ({ summary, isLoad
       <CardContent>
         <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
           <Stat
+            label="Account #"
+            value={summary.accountNumber}
+            isLoading={isLoading}
+          />
+          <Stat
             label="Net Liquidity"
-            value={data.netLiq.toLocaleString()}
-            unit="USD"
+            value={summary.liquidationValue.toLocaleString(undefined, { style: "currency", currency: "USD" })}
             isLoading={isLoading}
           />
           <Stat
-            label="Day's P/L"
-            value={data.dayPL.toLocaleString()}
-            unit="USD"
+            label="Equity"
+            value={summary.equity.toLocaleString(undefined, { style: "currency", currency: "USD" })}
             isLoading={isLoading}
           />
           <Stat
-            label="YTD P/L"
-            value={data.ytdPL.toLocaleString()}
-            unit="USD"
+            label="Cash"
+            value={summary.cash.toLocaleString(undefined, { style: "currency", currency: "USD" })}
             isLoading={isLoading}
           />
           <Stat
             label="Buying Power"
-            value={data.buyingPower.toLocaleString()}
-            unit="USD"
+            value={summary.buyingPower.toLocaleString(undefined, { style: "currency", currency: "USD" })}
             isLoading={isLoading}
           />
-          <Stat label="SPY Beta" value={data.beta} isLoading={isLoading} />
-          <Stat label="Sharpe Ratio" value={data.sharpe} isLoading={isLoading} />
+          {summary.dayTradingBuyingPower !== undefined && (
+            <Stat
+              label="Day Trading BP"
+              value={summary.dayTradingBuyingPower.toLocaleString(undefined, { style: "currency", currency: "USD" })}
+              isLoading={isLoading}
+            />
+          )}
         </div>
       </CardContent>
     </Card>

--- a/frontend/src/components/Portfolio/TradingHistoryTable.tsx
+++ b/frontend/src/components/Portfolio/TradingHistoryTable.tsx
@@ -87,7 +87,9 @@ const TradingHistoryTable: React.FC<Props> = ({ transactions }) => {
                   </Badge>
                 </TableCell>
                 <TableCell className="text-right">{trade.quantity}</TableCell>
-                <TableCell className="text-right">{trade.price !== undefined ? trade.price.toFixed(2) : '—'}</TableCell>
+                <TableCell className="text-right">
+                  {typeof trade.price === "number" ? trade.price.toFixed(2) : "—"}
+                </TableCell>
                 <TableCell className="text-right">{trade.amount.toLocaleString(undefined, { style: 'currency', currency: 'USD' })}</TableCell>
               </TableRow>
             ))}

--- a/frontend/src/components/overview/OverviewPage.tsx
+++ b/frontend/src/components/overview/OverviewPage.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useMemo, useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Card,
   CardContent,
@@ -21,8 +21,11 @@ import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import { OnboardingTeaser } from "@/components/OnboardingTeaser";
 import { useOnboarding } from "@/context/OnboardingContext";
+import { getUserPreferences } from "@/api/client";
+import { usePortfolioData } from "@/hooks/usePortfolioData";
 
 // --- Type Definitions ---
 type Bench = "SPY" | "QQQ" | "Custom Factor";
@@ -31,11 +34,29 @@ type Mover = { sym: string; name: string; chg: number; vol: string };
 
 export default function OverviewPage() {
   const { setShowOnboarding } = useOnboarding();
-  /** ------- MOCK DATA (replace with live) ------- */
-  const portfolio = {
-    netLiq: 127420, realized: 18920, unrealized: 1245, marginUtil: 0.31, buyingPower: 232000, excessLiq: 75000,
-    ccy: [{ccy:"USD", wt:0.92},{ccy:"EUR", wt:0.05},{ccy:"JPY", wt:0.03}],
-  };
+
+  // Track which broker is active so we can conditionally fetch portfolio data
+  const [activeBroker, setActiveBroker] = useState<string | null>(null);
+  const [checkingBroker, setCheckingBroker] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const prefs = await getUserPreferences();
+        setActiveBroker(prefs?.activeBroker || null);
+      } catch (e) {
+        console.error("Error checking active broker:", e);
+        setActiveBroker(null);
+      } finally {
+        setCheckingBroker(false);
+      }
+    })();
+  }, []);
+
+  // Load live portfolio data only when a broker is active
+  const { data, isLoading } = usePortfolioData(Boolean(activeBroker));
+  const summary = data?.portfolio?.summary;
+
   const perf = { sharpe:1.45, sortino:2.10, maxDD:-11.3 };
   const benchmarks: Bench[] = ["SPY", "QQQ", "Custom Factor"];
 
@@ -86,8 +107,6 @@ export default function OverviewPage() {
     setActiveBenches(prev => prev.includes(b) ? prev.filter(x=>x!==b) : [...prev, b]);
 
   /** ------- COMPUTED ------- */
-  const marginUtilPct = useMemo(()=> (portfolio.marginUtil*100).toFixed(0)+"%", [portfolio.marginUtil]);
-
   // The content is now wrapped in a single div, not an extra Layout component.
   // This prevents the "double nav" issue.
   return (
@@ -118,28 +137,50 @@ export default function OverviewPage() {
         <Card className="ink-card xl:col-span-2">
           <CardHeader><CardTitle>Real-time Portfolio Snapshot</CardTitle></CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
-              <Stat label="Net Liq" value={fmtCash(portfolio.netLiq)} />
-              <Stat label="Buying Power" value={fmtCash(portfolio.buyingPower)} />
-              <Stat label="Excess Liquidity" value={fmtCash(portfolio.excessLiq)} />
-              <Stat label="Realized P/L (YTD)" value={fmtCash(portfolio.realized)} isPositive />
-              <Stat label="Unrealized P/L (1D)" value={fmtCash(portfolio.unrealized)} isPositive />
-              <Stat label="Margin Utilization" value={marginUtilPct} />
-            </div>
-            <div className="mt-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <div>
-                <h3 className="text-xs text-muted-foreground mb-2">Currency Exposure</h3>
-                <div className="flex flex-wrap gap-2">
-                  {portfolio.ccy.map(c => (
-                    <Badge key={c.ccy} variant="secondary">{c.ccy} {Math.round(c.wt*100)}%</Badge>
-                  ))}
+            {checkingBroker || isLoading ? (
+              <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                <Stat label="Net Liq" loading />
+                <Stat label="Buying Power" loading />
+                <Stat label="Equity" loading />
+                <Stat label="Cash" loading />
+                <Stat label="P/L (Day)" loading />
+                <Stat label="P/L (YTD)" loading />
+              </div>
+            ) : !activeBroker ? (
+              <div className="space-y-4">
+                <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                  <Stat label="Net Liq" loading />
+                  <Stat label="Buying Power" loading />
+                  <Stat label="Equity" loading />
+                  <Stat label="Cash" loading />
+                  <Stat label="P/L (Day)" loading />
+                  <Stat label="P/L (YTD)" loading />
                 </div>
+                <p className="text-sm text-muted-foreground">
+                  No active broker connected. Set one in settings to view your portfolio.
+                </p>
+                <Button asChild size="sm" className="w-fit">
+                  <a href="/settings">Go to Settings</a>
+                </Button>
               </div>
-              <div>
-                <h3 className="text-xs text-muted-foreground mb-2">Equity Curve (mock)</h3>
-                <EquityArea />
+            ) : (
+              <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+                <Stat label="Net Liq" value={fmtCash(summary?.liquidationValue ?? 0)} />
+                <Stat label="Buying Power" value={fmtCash(summary?.buyingPower ?? 0)} />
+                <Stat label="Equity" value={fmtCash(summary?.equity ?? 0)} />
+                <Stat label="Cash" value={fmtCash(summary?.cash ?? 0)} />
+                <Stat
+                  label="P/L (Day)"
+                  value={fmtCash(summary?.dayPL ?? 0)}
+                  isPositive={(summary?.dayPL ?? 0) >= 0}
+                />
+                <Stat
+                  label="P/L (YTD)"
+                  value={fmtCash(summary?.ytdPL ?? 0)}
+                  isPositive={(summary?.ytdPL ?? 0) >= 0}
+                />
               </div>
-            </div>
+            )}
           </CardContent>
         </Card>
 
@@ -286,11 +327,15 @@ export default function OverviewPage() {
 }
 
 /** ---------- Reusable UI Components (Styled with Theme Variables) ---------- */
-function Stat({label, value, isPositive}:{label:string; value:string; isPositive?:boolean}) {
+function Stat({label, value, isPositive, loading}:{label:string; value?:string; isPositive?:boolean; loading?:boolean}) {
   return (
     <div className="bg-muted/40 rounded-lg p-3">
       <div className="text-xs text-muted-foreground">{label}</div>
-      <div className={`text-lg font-semibold text-card-foreground ${isPositive ? "text-green-400" : ""}`}>{value}</div>
+      {loading ? (
+        <Skeleton className="h-5 w-20 mt-1" />
+      ) : (
+        <div className={`text-lg font-semibold text-card-foreground ${isPositive ? "text-green-400" : ""}`}>{value ?? "—"}</div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/usePortfolioData.ts
+++ b/frontend/src/hooks/usePortfolioData.ts
@@ -2,10 +2,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { getActiveApiPortfolioData } from '@/api/brokerService';
 
-export function usePortfolioData() {
+/**
+ * Small wrapper around the portfolio query so pages can optionally disable the
+ * fetch (e.g. when no broker is connected).  Defaults to enabled.
+ */
+export function usePortfolioData(enabled: boolean = true) {
   return useQuery({
     queryKey: ['portfolio'],
-    queryFn: getActiveApiPortfolioData, 
+    queryFn: getActiveApiPortfolioData,
+    enabled,
   });
-  
 }


### PR DESCRIPTION
## Summary
- handle null trade prices in TradingHistoryTable
- parse Schwab transactions to select the security transfer item for price/quantity
- fetch and normalize Alpaca account activities for transaction history
- colorize holdings pie chart with per-position allocation including cash slice
- show real account metrics in PortfolioSummaryCard
- drive overview snapshot from the user's active broker with skeleton fallbacks
- allow disabling portfolio queries when no broker is connected
- compute day and year-to-date profit/loss for Alpaca and Schwab accounts and display them in the overview snapshot

## Testing
- `npm test` (fails: Could not read package.json)
- `npm run lint` (fails: Could not read package.json)
- `python -m pytest -q` (passes: no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_68a8d32273708331aa130ef7caf8ca47