### PR TITLE
Add backend proxy and UI for AI insights

### DIFF
--- a/backend/controllers/stockbotController.js
+++ b/backend/controllers/stockbotController.js
@@ -1,5 +1,7 @@
 import axios from "axios";
 import FormData from "form-data";
+import User from "../models/User.js";
+import { getBrokerCredentials } from "../config/getBrokerCredentials.js";
 
 const STOCKBOT_URL = process.env.STOCKBOT_URL;
 
@@ -119,5 +121,29 @@ export async function uploadPolicyProxy(req, res) {
     return res.json(data); // { policy_path: "/abs/server/path.zip" }
   } catch (e) {
     return res.status(400).json({ error: errMsg(e) });
+  }
+}
+
+/** GET /api/stockbot/insights */
+export async function getInsightsProxy(req, res) {
+  try {
+    const user = await User.findById(req.user.id);
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    const activeBroker = user.preferences?.activeBroker;
+    if (!activeBroker) {
+      return res.status(400).json({ error: "No active broker set" });
+    }
+
+    const credentials = await getBrokerCredentials(user, activeBroker);
+    const { data } = await axios.post(`${STOCKBOT_URL}/api/stockbot/insights`, {
+      broker: activeBroker,
+      credentials,
+    });
+    return res.json(data);
+  } catch (e) {
+    const status = e.response?.status || 500;
+    const body = e.response?.data || { error: errMsg(e) };
+    return res.status(status).json(body);
   }
 }

--- a/backend/routes/stockbotRoutes.js
+++ b/backend/routes/stockbotRoutes.js
@@ -10,6 +10,7 @@ import {
   getRunArtifactsProxy,
   getRunArtifactFileProxy,
   getRunBundleProxy,
+  getInsightsProxy,
 } from "../controllers/stockbotController.js";
 import { protectRoute } from "../middleware/protectRoute.js";
 
@@ -32,6 +33,9 @@ router.get("/runs/:id/files/:name", protectRoute, getRunArtifactFileProxy);
 router.get("/runs/:id/bundle", protectRoute, getRunBundleProxy);
 
 router.post("/policies/upload", protectRoute, upload.single("file"), uploadPolicyProxy);
+
+// AI insights
+router.get("/insights", protectRoute, getInsightsProxy);
 
 
 export default router;

--- a/frontend/src/api/stockbot.ts
+++ b/frontend/src/api/stockbot.ts
@@ -32,3 +32,10 @@ export async function downloadRunBundle(runId: string, includeModel = true): Pro
   return data as Blob;
 }
 
+export async function getAiInsights() {
+  const { data } = await axios.get(buildUrl("/api/stockbot/insights"), {
+    withCredentials: true,
+  });
+  return data as { insights: string[] };
+}
+

--- a/frontend/src/components/Portfolio/InsightsPanel.tsx
+++ b/frontend/src/components/Portfolio/InsightsPanel.tsx
@@ -1,6 +1,6 @@
 // src/components/Portfolio/InsightsPanel.tsx
-import React from 'react';
-import { Lightbulb, TrendingUp, AlertTriangle } from "lucide-react";
+import React, { useEffect, useState } from "react";
+import { Lightbulb } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -8,33 +8,30 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { getAiInsights } from "@/api/stockbot";
 
-type Props = {
+interface Props {
   positions: { symbol: string; value: number; percentage: number }[];
-};
+}
 
-const InsightsPanel: React.FC<Props> = ({ positions }) => {
-  if (!Array.isArray(positions)) {
-    return (
-      <div className="bg-white/5 rounded p-3 h-[160px] flex items-center justify-center">
-        <p className="text-sm text-red-400">No position data available for insights.</p>
-      </div>
-    );
-  }
+const InsightsPanel: React.FC<Props> = (_props) => {
+  const [insights, setInsights] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const insights: string[] = [];
-  const techExposure = positions
-    .filter((p) => ['AAPL', 'MSFT', 'GOOGL', 'NVDA'].includes(p.symbol))
-    .reduce((acc, p) => acc + p.percentage, 0);
-
-  if (techExposure > 50) {
-    insights.push(`⚠️ High tech exposure (${techExposure.toFixed(1)}%).`);
-  }
-  if (positions.length === 0) {
-    insights.push(`You have no visible positions at the moment.`);
-  }
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getAiInsights();
+        setInsights(data.insights || []);
+      } catch (e: any) {
+        setError(e?.message || "Failed to load insights");
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
 
   return (
     <Card className="ink-card">
@@ -45,31 +42,25 @@ const InsightsPanel: React.FC<Props> = ({ positions }) => {
         </CardTitle>
         <CardDescription>AI-generated observations about your portfolio.</CardDescription>
       </CardHeader>
-      <CardContent className="space-y-4">
-        <Alert>
-          <TrendingUp className="h-4 w-4" />
-          <AlertTitle>Positive Trend</AlertTitle>
-          <AlertDescription>
-            Your tech sector holdings (AAPL, NVDA) have outperformed the S&P 500 by 4% this month.
-          </AlertDescription>
-        </Alert>
-
-        <div className="p-4 rounded-lg bg-muted/40">
-          <h4 className="font-semibold mb-2">Key Observations</h4>
+      <CardContent>
+        {loading ? (
+          <div className="space-y-2">
+            <div className="text-sm text-muted-foreground">Generating insights...</div>
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-4 w-1/2" />
+            <Skeleton className="h-4 w-2/3" />
+          </div>
+        ) : error ? (
+          <p className="text-sm text-red-400">{error}</p>
+        ) : insights.length ? (
           <ul className="list-disc list-inside text-sm space-y-1 text-muted-foreground">
-            <li>High concentration in NVDA (28% of portfolio).</li>
-            <li>Low exposure to defensive sectors like Utilities.</li>
-            <li>Realized P/L is primarily driven by short-term trades.</li>
+            {insights.map((txt, i) => (
+              <li key={i}>{txt}</li>
+            ))}
           </ul>
-        </div>
-
-        <Alert variant="destructive">
-          <AlertTriangle className="h-4 w-4" />
-          <AlertTitle>Risk Warning</AlertTitle>
-          <AlertDescription>
-            Your portfolio's beta is 1.45, indicating higher volatility than the market average. Consider hedging strategies.
-          </AlertDescription>
-        </Alert>
+        ) : (
+          <p className="text-sm text-muted-foreground">No insights available.</p>
+        )}
       </CardContent>
     </Card>
   );

--- a/stockbot/api/controllers/insights_controller.py
+++ b/stockbot/api/controllers/insights_controller.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from providers.provider_manager import ProviderManager
+
+class InsightsRequest(BaseModel):
+    broker: str
+    credentials: dict
+
+
+def generate_insights(req: InsightsRequest) -> dict:
+    provider = ProviderManager.get_provider(req.broker, req.credentials)
+    summary = provider.get_account_summary()
+    equity = summary.get("equity", 0)
+    bot_name = "default"
+    insight_text = f"Account equity is ${equity:,.2f} while bot '{bot_name}' monitors the market."
+    return {"insights": [insight_text], "accountValue": equity, "bot": bot_name}

--- a/stockbot/api/routes/stockbot_routes.py
+++ b/stockbot/api/routes/stockbot_routes.py
@@ -11,6 +11,7 @@ from api.controllers.stockbot_controller import (
     save_policy_upload,
     bundle_zip,   # <- expose bundle
 )
+from api.controllers.insights_controller import InsightsRequest, generate_insights
 
 router = APIRouter()
 
@@ -45,3 +46,7 @@ def get_run_bundle(run_id: str, include_model: bool = True):
 @router.post("/policies")
 async def upload_policy(file: UploadFile = File(...)):
     return await save_policy_upload(file)
+
+@router.post("/insights")
+def post_insights(req: InsightsRequest):
+    return generate_insights(req)

--- a/stockbot/providers/alpaca_provider.py
+++ b/stockbot/providers/alpaca_provider.py
@@ -84,6 +84,17 @@ class AlpacaProvider(BaseProvider):
         print(self.api_key)
         return self._request("GET", "/v2/account")
 
+    def get_account_summary(self) -> Dict[str, Any]:
+        account = self.get_account()
+        return {
+            "accountNumber": account.get("account_number", "—"),
+            "liquidationValue": float(account.get("portfolio_value", 0)),
+            "equity": float(account.get("equity", 0)),
+            "cash": float(account.get("cash", 0)),
+            "buyingPower": float(account.get("buying_power", 0)),
+            "dayTradingBuyingPower": float(account.get("daytrading_buying_power", 0)),
+        }
+
     def get_positions(self) -> List[Dict[str, Any]]:
         return self._request("GET", "/v2/positions")
 
@@ -144,21 +155,12 @@ class AlpacaProvider(BaseProvider):
         Combines account summary and positions into a single portfolio object.
         Matches the structure expected by the frontend.
         """
-        account = self.get_account()
+        summary = self.get_account_summary()
         raw_positions = self.get_positions()
         try:
             raw_transactions = self.get_transactions()
         except Exception:
             raw_transactions = []
-
-        summary = {
-            "accountNumber": account.get("account_number", "—"),
-            "liquidationValue": float(account.get("portfolio_value", 0)),
-            "equity": float(account.get("equity", 0)),
-            "cash": float(account.get("cash", 0)),
-            "buyingPower": float(account.get("buying_power", 0)),
-            "dayTradingBuyingPower": float(account.get("daytrading_buying_power", 0)),
-        }
 
         # ✅ Normalize positions to a common structure for the frontend
         positions = []

--- a/stockbot/providers/base_provider.py
+++ b/stockbot/providers/base_provider.py
@@ -48,6 +48,10 @@ class BaseProvider(ABC):
         :return: list of OHLC+volume dicts for symbol between start/end
         """
 
+    @abstractmethod
+    def get_account_summary(self) -> Dict[str, Any]:
+        """Return a high-level account summary such as equity, cash, etc."""
+
     def _full_url(self, path: str) -> str:
         return f"{self.base_url}/{path.lstrip('/')}"
 


### PR DESCRIPTION
## Summary
- Add backend and stockbot routes to generate AI insights
- Fetch insights in frontend panel with skeleton loading state
- Expose helper to call insights API
- Provide account summary abstraction and Alpaca implementation for insights

## Testing
- `npm test` (backend) *(fails: Missing script "test")*
- `npm run lint` (backend) *(fails: Missing script "lint")*
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (frontend) *(fails: next: not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'stockbot')*


------
https://chatgpt.com/codex/tasks/task_e_68a8ed065e5483319fba11e0932ed60e