### PR TITLE
Trim Schwab credentials before token requests

### DIFF
--- a/backend/config/schwab.js
+++ b/backend/config/schwab.js
@@ -11,9 +11,13 @@ async function updateSchwabTokens(user, updates) {
   const decrypted = user.getDecryptedTokens();
   const { app_key, app_secret } = decrypted.schwab_tokens;
 
+  // Trim any stray whitespace from stored credentials
+  const trimmedKey = app_key?.trim();
+  const trimmedSecret = app_secret?.trim();
+
   user.schwab_tokens = {
-    app_key,
-    app_secret,
+    app_key: trimmedKey,
+    app_secret: trimmedSecret,
     access_token: updates.access_token || decrypted.schwab_tokens.access_token,
     refresh_token: updates.refresh_token || decrypted.schwab_tokens.refresh_token,
     expires_at: updates.expires_at || decrypted.schwab_tokens.expires_at
@@ -51,7 +55,8 @@ export async function refreshSchwabAccessTokenInternal(userId) {
   }
 
   const redirectUri = 'https://127.0.0.1';
-  const encodedAuth = base64.encode(`${app_key}:${app_secret}`);
+  const authString = `${app_key?.trim()}:${app_secret?.trim()}`;
+  const encodedAuth = base64.encode(authString);
 
   try {
     const res = await axios.post(
@@ -96,7 +101,8 @@ export async function exchangeCodeForTokensInternal(code, userId) {
   const { app_key, app_secret } = decrypted.schwab_tokens;
 
   const redirectUri = 'https://127.0.0.1';
-  const encodedAuth = base64.encode(`${app_key}:${app_secret}`);
+  const authString = `${app_key?.trim()}:${app_secret?.trim()}`;
+  const encodedAuth = base64.encode(authString);
 
   try {
     const res = await axios.post(

--- a/backend/controllers/schwabController.js
+++ b/backend/controllers/schwabController.js
@@ -68,7 +68,9 @@ export const getSchwabAccountStatus = async (req, res) => {
 export const setSchwabCredentials = async (req, res) => {
   try {
     const { app_key, app_secret } = req.body;
-    if (!app_key || !app_secret) {
+    const trimmedKey = app_key?.trim();
+    const trimmedSecret = app_secret?.trim();
+    if (!trimmedKey || !trimmedSecret) {
       return res.status(400).json({ message: 'Missing credentials' });
     }
 
@@ -80,8 +82,8 @@ export const setSchwabCredentials = async (req, res) => {
     // Mongoose pre-save hook will encrypt these
     user.schwab_tokens = {
       ...user.schwab_tokens,
-      app_key,
-      app_secret
+      app_key: trimmedKey,
+      app_secret: trimmedSecret
     };
 
     await user.save();


### PR DESCRIPTION
## Summary
- trim any whitespace on Schwab app key and secret when saving and exchanging tokens
- use trimmed credentials when generating Basic auth headers for token refresh and exchange

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f394de3c833191753e36449dfe32