### PR TITLE
feat: add market highlights endpoint

### DIFF
--- a/backend/controllers/stockbotController.js
+++ b/backend/controllers/stockbotController.js
@@ -147,3 +147,27 @@ export async function getInsightsProxy(req, res) {
     return res.status(status).json(body);
   }
 }
+
+/** GET /api/stockbot/highlights */
+export async function getHighlightsProxy(req, res) {
+  try {
+    const user = await User.findById(req.user.id);
+    if (!user) return res.status(404).json({ error: "User not found" });
+
+    const activeBroker = user.preferences?.activeBroker;
+    if (!activeBroker) {
+      return res.status(400).json({ error: "No active broker set" });
+    }
+
+    const credentials = await getBrokerCredentials(user, activeBroker);
+    const { data } = await axios.post(`${STOCKBOT_URL}/api/stockbot/highlights`, {
+      broker: activeBroker,
+      credentials,
+    });
+    return res.json(data);
+  } catch (e) {
+    const status = e.response?.status || 500;
+    const body = e.response?.data || { error: errMsg(e) };
+    return res.status(status).json(body);
+  }
+}

--- a/backend/routes/stockbotRoutes.js
+++ b/backend/routes/stockbotRoutes.js
@@ -11,6 +11,7 @@ import {
   getRunArtifactFileProxy,
   getRunBundleProxy,
   getInsightsProxy,
+  getHighlightsProxy,
 } from "../controllers/stockbotController.js";
 import { protectRoute } from "../middleware/protectRoute.js";
 
@@ -36,6 +37,7 @@ router.post("/policies/upload", protectRoute, upload.single("file"), uploadPolic
 
 // AI insights
 router.get("/insights", protectRoute, getInsightsProxy);
+router.get("/highlights", protectRoute, getHighlightsProxy);
 
 
 export default router;

--- a/frontend/src/api/stockbot.ts
+++ b/frontend/src/api/stockbot.ts
@@ -39,3 +39,10 @@ export async function getAiInsights() {
   return data as { insights: string[] };
 }
 
+export async function getMarketHighlights() {
+  const { data } = await axios.get(buildUrl("/api/stockbot/highlights"), {
+    withCredentials: true,
+  });
+  return data as { highlights: string };
+}
+

--- a/frontend/src/components/overview/OverviewPage.tsx
+++ b/frontend/src/components/overview/OverviewPage.tsx
@@ -13,8 +13,6 @@ import {
   Table,
   TableBody,
   TableCell,
-  TableHead,
-  TableHeader,
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -22,10 +20,12 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Separator } from "@/components/ui/separator";
 import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { OnboardingTeaser } from "@/components/OnboardingTeaser";
 import { useOnboarding } from "@/context/OnboardingContext";
 import { getUserPreferences } from "@/api/client";
 import { usePortfolioData } from "@/hooks/usePortfolioData";
+import { getMarketHighlights } from "@/api/stockbot";
 
 // --- Type Definitions ---
 type Bench = "SPY" | "QQQ" | "Custom Factor";
@@ -78,18 +78,23 @@ export default function OverviewPage() {
   const perf = { sharpe:1.45, sortino:2.10, maxDD:-11.3 };
   const benchmarks: Bench[] = ["SPY", "QQQ", "Custom Factor"];
 
-  const alerts = [
-    { t:"10:57", text:"AAPL Unusual Volume: 2.4× 30-day avg" },
-    { t:"10:54", text:"NVDA IV spike +7% (1h)" },
-  ];
-  const econ = [
-    {t:"08:30", event:"CPI (YoY)", exp:"3.2%", act:"3.1%", imp:"High"},
-    {t:"10:00", event:"Consumer Sentiment", exp:"72.0", act:"—",   imp:"Med"},
-  ];
-  const earnings = [
-    {t:"After", sym:"MSFT", note:"Earnings today"},
-    {t:"After", sym:"TSLA", note:"Earnings today"},
-  ];
+  const [highlights, setHighlights] = useState<string>("");
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { highlights } = await getMarketHighlights();
+        setHighlights(highlights);
+      } catch (e) {
+        console.error("Failed to load highlights", e);
+      }
+    })();
+  }, []);
+
+  const highlightItems = useMemo(
+    () => (highlights ? highlights.split("\n").filter(Boolean) : []),
+    [highlights]
+  );
 
   const indices: IdxRow[] = [
     {name:"S&P 500 (SPY)", chg:+0.32},
@@ -245,34 +250,25 @@ export default function OverviewPage() {
       <section className="grid grid-cols-1 xl:grid-cols-3 gap-6">
         {/* News & Macro */}
         <Card className="ink-card">
-          <CardHeader><CardTitle>News & Macro Highlights</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle>News & Macro Highlights</CardTitle>
+          </CardHeader>
           <CardContent>
-            <div className="space-y-2 text-sm">
-              {alerts.map((a,i)=>(
-                <div key={i} className="flex items-center gap-2">
-                  <Badge variant="destructive" className="text-xs">Alert</Badge>
-                  <span>{a.t} • {a.text}</span>
-                </div>
-              ))}
-            </div>
-            <Separator className="my-4" />
-            <h3 className="text-xs text-muted-foreground mb-2">Economic Releases</h3>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Time</TableHead><TableHead>Event</TableHead><TableHead>Exp</TableHead><TableHead>Act</TableHead><TableHead>Imp</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {econ.map((e,i)=>(
-                  <TableRow key={i}><TableCell>{e.t}</TableCell><TableCell>{e.event}</TableCell><TableCell>{e.exp}</TableCell><TableCell>{e.act}</TableCell><TableCell>{e.imp}</TableCell></TableRow>
+            {highlights ? (
+              <ScrollArea className="h-48">
+                <ul className="space-y-2 text-sm list-disc pl-4">
+                  {highlightItems.map((item, idx) => (
+                    <li key={idx}>{item}</li>
+                  ))}
+                </ul>
+              </ScrollArea>
+            ) : (
+              <div className="space-y-2">
+                {[...Array(4)].map((_, i) => (
+                  <Skeleton key={i} className="h-4 w-full" />
                 ))}
-              </TableBody>
-            </Table>
-            <h3 className="text-xs text-muted-foreground mt-4 mb-2">Earnings Calendar</h3>
-            <div className="space-y-1 text-sm">
-              {earnings.map((e,i)=>(<div key={i}>{e.sym} — {e.note}</div>))}
-            </div>
+              </div>
+            )}
           </CardContent>
         </Card>
 

--- a/stockbot/api/controllers/highlights_controller.py
+++ b/stockbot/api/controllers/highlights_controller.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+from providers.provider_manager import ProviderManager
+from utils.web_search import fetch_financial_snippets
+
+class HighlightsRequest(BaseModel):
+    broker: str
+    credentials: dict
+
+
+def generate_highlights(req: HighlightsRequest) -> dict:
+    provider = ProviderManager.get_provider(req.broker, req.credentials)
+    provider_name = provider.__class__.__name__.replace("Provider", "")
+    highlights = fetch_financial_snippets()
+    bot_name = "default"
+    return {"provider": provider_name, "bot": bot_name, "highlights": highlights}

--- a/stockbot/api/routes/stockbot_routes.py
+++ b/stockbot/api/routes/stockbot_routes.py
@@ -12,6 +12,7 @@ from api.controllers.stockbot_controller import (
     bundle_zip,   # <- expose bundle
 )
 from api.controllers.insights_controller import InsightsRequest, generate_insights
+from api.controllers.highlights_controller import HighlightsRequest, generate_highlights
 
 router = APIRouter()
 
@@ -50,3 +51,7 @@ async def upload_policy(file: UploadFile = File(...)):
 @router.post("/insights")
 def post_insights(req: InsightsRequest):
     return generate_insights(req)
+
+@router.post("/highlights")
+def post_highlights(req: HighlightsRequest):
+    return generate_highlights(req)


### PR DESCRIPTION
## Summary
- add StockBot API controller and route for market highlights
- proxy highlights request through backend to StockBot
- fetch and display highlights on overview page
- style highlights using shadcn components

## Testing
- `npm test` (backend) *(fails: Missing script)*
- `npm test` (frontend) *(fails: Missing script)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'stockbot')*

------
https://chatgpt.com/codex/tasks/task_e_68a8f536d494833186ba5c151eeaeb1b