### PR TITLE
Add CI workflow for backend, frontend, and stockbot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.11.3'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements.txt
       - run: pytest


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run npm tests and lints for backend and frontend, and pytest for stockbot

## Testing
- `npm test` (backend) *(fails: Missing script: "test")*
- `npm test` (frontend) *(fails: Missing script: "test")*
- `npm run lint` (frontend) *(fails: next: not found)*
- `npm run lint` (backend) *(fails: Missing script: "lint")*
- `pytest stockbot` *(fails: ModuleNotFoundError: No module named 'stockbot')*


------
https://chatgpt.com/codex/tasks/task_e_68aa61c844dc8331a2cd0591a9e68a41