### PR TITLE
Add basic tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        project: [backend, frontend]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+        working-directory: ${{ matrix.project }}
+      - run: npm test
+        working-directory: ${{ matrix.project }}
+
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements-test.txt
+        working-directory: stockbot
+      - run: pytest
+        working-directory: stockbot

--- a/backend/controllers/userController.test.js
+++ b/backend/controllers/userController.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getPreferences } from './userController.js';
+
+vi.mock('../models/User.js', () => ({
+  default: { findById: vi.fn() }
+}));
+import User from '../models/User.js';
+
+function createRes() {
+  return {
+    json: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+  };
+}
+
+describe('getPreferences', () => {
+  it('returns defaults when user has no preferences', async () => {
+    const req = { user: { _id: '123' } };
+    User.findById.mockResolvedValue({ preferences: null });
+    const res = createRes();
+
+    await getPreferences(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      preferences: {
+        model: 'qwen3:8b',
+        format: 'markdown',
+        voiceEnabled: false,
+        activeBroker: 'alpaca',
+      },
+    });
+  });
+
+  it('merges user preferences with defaults', async () => {
+    const req = { user: { _id: '123' } };
+    User.findById.mockResolvedValue({ preferences: { toObject: () => ({ voiceEnabled: true }) } });
+    const res = createRes();
+
+    await getPreferences(req, res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      preferences: {
+        model: 'qwen3:8b',
+        format: 'markdown',
+        voiceEnabled: true,
+        activeBroker: 'alpaca',
+      },
+    });
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "infisical run -- npm run start:dev",
     "start:dev": "nodemon server.js",
-    "test": "jest"
+    "test": "vitest run"
 
   },
   "dependencies": {
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@infisical/cli": "^0.41.96",
     "cross-env": "^7.0.3",
-    "nodemon": "^3.1.0"
+    "nodemon": "^3.1.0",
+    "vitest": "^2.1.1"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "build": "cross-env NODE_ENV=production next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@lobehub/tts": "^2.0.1",
@@ -61,6 +61,13 @@
     "mkcert": "^3.2.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.17",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "vitest": "^2.1.1",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^26.1.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "vite": "^6.0.1"
   }
 }

--- a/frontend/src/components/ui/__tests__/badge.test.tsx
+++ b/frontend/src/components/ui/__tests__/badge.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import { Badge } from '../badge';
+
+test('renders provided text', () => {
+  render(<Badge>Test Badge</Badge>);
+  expect(screen.getByText('Test Badge')).toBeInTheDocument();
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./vitest.setup.ts'],
+    globals: true,
+  },
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/stockbot/requirements-test.txt
+++ b/stockbot/requirements-test.txt
@@ -1,0 +1,3 @@
+fastapi
+httpx
+pytest

--- a/stockbot/tests/test_runs.py
+++ b/stockbot/tests/test_runs.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+import asyncio
+from httpx import AsyncClient, ASGITransport
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from fastapi import FastAPI
+from api.routes import stockbot_routes
+from api.routes.stockbot_routes import router as stockbot_router
+
+app = FastAPI()
+app.include_router(stockbot_router, prefix="/api/stockbot")
+
+def test_get_runs(monkeypatch):
+    async def run_test():
+        monkeypatch.setattr(stockbot_routes, "list_runs", lambda: [{"id": "1"}])
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/stockbot/runs")
+        assert resp.status_code == 200
+        assert resp.json() == [{"id": "1"}]
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary
- set up Vitest config and sample component test for frontend
- add Vitest unit test for backend user preferences controller
- add FastAPI test suite and lightweight requirements for stockbot service
- configure GitHub Actions to run Node and Python tests

## Testing
- `npm test` *(fails: vitest not found)*
- `cd frontend && npm test` *(fails: vitest not found)*
- `cd stockbot && pytest tests/test_runs.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa683fea20833181a09f629d4d3804