### PR TITLE
Add data-accent attribute to html tag

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -18,7 +18,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" className="dark" data-accent="violet">
       <body className={inter.className}>
         {/* These divs render the blobs. */}
         <div className="blob blob-accent"></div>


### PR DESCRIPTION
Sets data-accent="violet" on the html element in RootLayout to enable accent color customization, likely for theming or styling purposes.