### PR TITLE
Use POST for refresh token with origin check

### DIFF
--- a/backend/middleware/verifyOrigin.js
+++ b/backend/middleware/verifyOrigin.js
@@ -1,0 +1,11 @@
+export const verifyOrigin = (req, res, next) => {
+  const origin = req.headers.origin;
+  const allowedOrigin = process.env.FRONTEND_URL;
+
+  if (!origin || origin === allowedOrigin) {
+    return next();
+  }
+
+  return res.status(403).json({ message: 'Forbidden origin' });
+};
+

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,13 +1,18 @@
 // routes/authRoutes.js
 import express from 'express';
-import { registerUser, loginUser, logoutUser, refreshAccessToken } from '../controllers/authController.js';
+import {
+  registerUser,
+  loginUser,
+  logoutUser,
+  refreshAccessToken
+} from '../controllers/authController.js';
+import { verifyOrigin } from '../middleware/verifyOrigin.js';
 
 const router = express.Router();
 
 router.post('/register', registerUser);
 router.post('/login', loginUser);
 router.post('/logout', logoutUser);
-router.get('/refresh', refreshAccessToken);
-
+router.post('/refresh', verifyOrigin, refreshAccessToken);
 
 export default router;

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -10,7 +10,7 @@ console.log(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api`);
 
 // ✅ Auth endpoints (no token header required anymore)
 export const checkAuth = () =>
-  api.get("/auth/refresh"); // will use cookie
+  api.post("/auth/refresh"); // will use cookie
 
 export const signup = (data) =>
   api.post("/auth/register", data);


### PR DESCRIPTION
## Summary
- switch refresh token endpoint to POST and add origin check middleware
- update client to use POST for `/auth/refresh`

## Testing
- `npm test` (fails: sh: 1: vitest: not found)
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2festree)
- `npm test` (frontend) (fails: sh: 1: vitest: not found)
- `npm install` (frontend) (fails: 403 Forbidden - GET https://registry.npmjs.org/react)`


------
https://chatgpt.com/codex/tasks/task_e_68aa7d98d79083319feebb72fa11a9be