### PR TITLE
Add request validation for auth routes

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "express-ws": "^5.0.2",
+    "express-validator": "^7.0.1",
     "form-data": "^4.0.4",
     "jsonwebtoken": "^9.0.0",
     "mongoose": "^8.0.0",

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,13 +1,19 @@
 // routes/authRoutes.js
 import express from 'express';
-import { registerUser, loginUser, logoutUser, refreshAccessToken } from '../controllers/authController.js';
+import {
+  registerUser,
+  loginUser,
+  logoutUser,
+  refreshAccessToken,
+  registerValidation,
+  loginValidation,
+} from '../controllers/authController.js';
 
 const router = express.Router();
 
-router.post('/register', registerUser);
-router.post('/login', loginUser);
+router.post('/register', registerValidation, registerUser);
+router.post('/login', loginValidation, loginUser);
 router.post('/logout', logoutUser);
 router.get('/refresh', refreshAccessToken);
-
 
 export default router;


### PR DESCRIPTION
## Summary
- install express-validator for backend validation
- add validation schemas for registration and login
- enforce request validation on auth routes

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7dca2e7c83319716503267860b3b