### PR TITLE
refactor: fetch user profile via react query

### DIFF
--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+import api from '@/api/client';
+
+export interface UserProfile {
+  username: string;
+  // other fields can be added here as needed
+}
+
+async function fetchProfile(): Promise<UserProfile> {
+  const { data } = await api.get('/users/profile');
+  return data;
+}
+
+export function useProfile() {
+  return useQuery({
+    queryKey: ['profile'],
+    queryFn: fetchProfile,
+  });
+}


### PR DESCRIPTION
## Summary
- create React Query hook for fetching user profile
- use hook in Sidebar with loading and error states

## Testing
- `npm test` *(fails: vitest not found, dependency installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7de4a8e48331902dfad606f5829b