### PR TITLE
refactor: centralize user profile access

### DIFF
--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -3,7 +3,10 @@ import api from '@/api/client';
 
 export interface UserProfile {
   username: string;
-  // other fields can be added here as needed
+  email?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  preferences?: Record<string, any>;
 }
 
 async function fetchProfile(): Promise<UserProfile> {

--- a/frontend/src/app/account/page.tsx
+++ b/frontend/src/app/account/page.tsx
@@ -1,11 +1,10 @@
  'use client';
 
- import { useEffect, useState } from 'react';
- import { getUserPreferences } from '@/api/client';
  import LogoutButton from '@/components/LogoutButton';
  import { usePortfolioData } from '@/hooks/usePortfolioData';
  import { useSchwabStatus } from '@/hooks/useSchwabStatus';
  import { useAlpacaStatus } from '@/hooks/useAlpacaStatus';
+ import { useProfile } from '@/api/user';
 
  /**
   * AccountPage shows high‑level information about the logged‑in user and their
@@ -17,36 +16,11 @@
   * real account values from the active broker.
   */
  export default function AccountPage() {
-   const [user, setUser] = useState<any>(null);
-   const [preferences, setPreferences] = useState<any>(null);
-   const [email, setEmail] = useState<string | null>(null);
-   const [createdAt, setCreatedAt] = useState<string | null>(null);
-   const [updatedAt, setUpdatedAt] = useState<string | null>(null);
-
-   // Pull the latest user preferences on mount
-   useEffect(() => {
-     getUserPreferences().then(({ data }) => {
-       setUser(data);
-       console.log(data);
-     });
-
-     fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/users/profile`, {
-       credentials: 'include', // send HTTP-only cookie
-     })
-       .then((r) => {
-         if (!r.ok) throw new Error('Not authenticated');
-         return r.json();
-       })
-       .then((data) => {
-         if (data.preferences) setPreferences(data.preferences);
-         if (data.email) setEmail(data.email);
-         if (data.createdAt) setCreatedAt(data.createdAt);
-         if (data.updatedAt) setUpdatedAt(data.updatedAt);
-       })
-       .catch(() => {
-         setPreferences('--');
-       });
-   }, []);
+   const { data: user } = useProfile();
+   const preferences = user?.preferences;
+   const email = user?.email;
+   const createdAt = user?.createdAt;
+   const updatedAt = user?.updatedAt;
    
 
    // Load a fresh snapshot of the portfolio summary.  This hook will call the

--- a/frontend/src/app/chatbot/page.tsx
+++ b/frontend/src/app/chatbot/page.tsx
@@ -6,6 +6,7 @@ import { FaUserCircle } from 'react-icons/fa';
 import ProfilePanel from '@/components/ProfilePanel';
 import JarvisPanel from '@/components/Jarvis/JarvisPanel';
 import { useWarmPortfolioData } from '@/hooks/useWarmPortfolioData';
+import { useProfile } from '@/api/user';
 
 
 export default function Chatbot() {
@@ -22,7 +23,8 @@ export default function Chatbot() {
   const [darkMode, setDarkMode]         = useState(true);
   const [voiceEnabled, setVoiceEnabled] = useState(false);
   const [profileOpen, setProfileOpen]   = useState(false);
-  const [username, setUsername]         = useState('User');
+  const { data: profile } = useProfile();
+  const username = profile?.username || 'Guest';
 
   useEffect(() => {
     // Animations
@@ -36,20 +38,6 @@ export default function Chatbot() {
     gsap.to(blob2Ref.current, { x: -50, y: 30, duration: 12, repeat: -1, yoyo: true, ease: 'sine.inOut' });
     gsap.to(blob3Ref.current, { x: 40, y: 40, duration: 8, repeat: -1, yoyo: true, ease: 'sine.inOut' });
 
-    // Secure cookie-based profile fetch
-    fetch(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/users/profile`, {
-      credentials: 'include', // send HTTP-only cookie
-    })
-      .then((r) => {
-        if (!r.ok) throw new Error('Not authenticated');
-        return r.json();
-      })
-      .then((data) => {
-        if (data.username) setUsername(data.username);
-      })
-      .catch(() => {
-        setUsername('Guest');
-      });
   }, []);
 
   useEffect(() => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -40,7 +40,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import { logout } from "@/api/client";
-import { useProfile } from "@/api/users";
+import { useProfile } from "@/api/user";
 import { useAuth } from "@/context/AuthContext";
 
 // ---- props ----


### PR DESCRIPTION
## Summary
- expand `user` API with email, timestamps, and preferences
- refactor frontend pages/components to use `useProfile`

## Testing
- `cd backend && npm test` *(fails: vitest not found)*
- `cd frontend && npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa87a9acf083319bb2d0511edaf599