### PR TITLE
refactor: modularize overview utilities and hooks

### DIFF
--- a/frontend/src/components/overview/hooks/useActiveBroker.ts
+++ b/frontend/src/components/overview/hooks/useActiveBroker.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { getUserPreferences } from "@/api/client";
+
+export function useActiveBroker() {
+  const [activeBroker, setActiveBroker] = useState<string | null>(null);
+  const [checkingBroker, setCheckingBroker] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const prefs = await getUserPreferences();
+        setActiveBroker(prefs?.activeBroker || null);
+      } catch (e) {
+        console.error("Error checking active broker:", e);
+        setActiveBroker(null);
+      } finally {
+        setCheckingBroker(false);
+      }
+    })();
+  }, []);
+
+  return { activeBroker, checkingBroker };
+}

--- a/frontend/src/components/overview/hooks/useMarketHighlights.ts
+++ b/frontend/src/components/overview/hooks/useMarketHighlights.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { getMarketHighlights } from "@/api/stockbot";
+import { parseHighlights, HighlightSection } from "../lib";
+
+interface Highlights {
+  marketHighlights?: HighlightSection;
+  relevantEvents?: HighlightSection;
+  calendarEvents?: HighlightSection;
+}
+
+export function useMarketHighlights() {
+  const [sections, setSections] = useState<Highlights>({});
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const { highlights } = await getMarketHighlights();
+        const parsed = parseHighlights(highlights);
+        setSections({
+          marketHighlights: parsed.find(s => /market/i.test(s.title)),
+          relevantEvents: parsed.find(s => /relevant/i.test(s.title)),
+          calendarEvents: parsed.find(s => /calendar/i.test(s.title)),
+        });
+      } catch (e) {
+        console.error("Failed to load highlights", e);
+      }
+    })();
+  }, []);
+
+  return sections;
+}

--- a/frontend/src/components/overview/hooks/useOnboardingStatus.ts
+++ b/frontend/src/components/overview/hooks/useOnboardingStatus.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from "react";
+
+export function useOnboardingStatus() {
+  const [isOnboardingDone, setIsOnboardingDone] = useState(true);
+
+  useEffect(() => {
+    const done = localStorage.getItem('onboarding_done_v1') === 'true';
+    setIsOnboardingDone(done);
+  }, []);
+
+  return isOnboardingDone;
+}

--- a/frontend/src/components/overview/lib/fmtCash.ts
+++ b/frontend/src/components/overview/lib/fmtCash.ts
@@ -1,0 +1,7 @@
+export function fmtCash(n: number) {
+  return n.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+}

--- a/frontend/src/components/overview/lib/index.ts
+++ b/frontend/src/components/overview/lib/index.ts
@@ -1,0 +1,3 @@
+export { fmtCash } from "./fmtCash";
+export { parseHighlights } from "./parseHighlights";
+export type { HighlightSection } from "./parseHighlights";

--- a/frontend/src/components/overview/lib/parseHighlights.ts
+++ b/frontend/src/components/overview/lib/parseHighlights.ts
@@ -1,0 +1,28 @@
+export type HighlightSection = { title: string; items: string[] };
+
+export function parseHighlights(text: string): HighlightSection[] {
+  return text
+    .split(/\n\s*\n/)
+    .map(block => {
+      const rawLines = block.split("\n");
+      if (!rawLines.length) return null;
+      const [titleLine, ...rest] = rawLines;
+
+      const items: string[] = [];
+      let current = "";
+      rest.forEach(line => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
+        if (/^[-*\u2022]\s*/.test(trimmed)) {
+          if (current) items.push(current.trim());
+          current = trimmed.replace(/^[-*\u2022]\s*/, "");
+        } else {
+          current += (current ? " " : "") + trimmed;
+        }
+      });
+      if (current) items.push(current.trim());
+
+      return { title: titleLine.trim(), items } as HighlightSection;
+    })
+    .filter(Boolean) as HighlightSection[];
+}

--- a/frontend/src/components/overview/shared/EquityArea.tsx
+++ b/frontend/src/components/overview/shared/EquityArea.tsx
@@ -1,0 +1,17 @@
+export function EquityArea({tone}:{tone?:"blue"|"purple"}) {
+  const c = tone==="blue" ? "#3b82f6" : "#8b5cf6"; // blue-500, violet-500
+  return (
+    <div className="h-32 rounded-lg bg-muted/40 flex items-center justify-center">
+      <svg viewBox="0 0 100 40" className="w-full h-full p-2" style={{color:c}}>
+        <defs>
+          <linearGradient id={`g-eq-${tone??"default"}`} x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor="currentColor" stopOpacity=".4" />
+            <stop offset="100%" stopColor="currentColor" stopOpacity=".05" />
+          </linearGradient>
+        </defs>
+        <path d="M0,30 L10,28 L20,32 L30,24 L40,26 L50,18 L60,22 L70,15 L80,16 L90,8 L100,12 L100,40 L0,40 Z" fill={`url(#g-eq-${tone??"default"})`} />
+        <polyline fill="none" stroke="currentColor" strokeWidth="1.5" points="0,30 10,28 20,32 30,24 40,26 50,18 60,22 70,15 80,16 90,8 100,12" />
+      </svg>
+    </div>
+  );
+}

--- a/frontend/src/components/overview/shared/Metric.tsx
+++ b/frontend/src/components/overview/shared/Metric.tsx
@@ -1,0 +1,8 @@
+export function Metric({label, value}:{label:string; value:string}) {
+  return (
+    <div className="bg-muted/40 rounded-lg p-2">
+      <div className="text-muted-foreground">{label}</div>
+      <div className="font-mono text-card-foreground">{value}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/overview/shared/Stat.tsx
+++ b/frontend/src/components/overview/shared/Stat.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function Stat({label, value, isPositive, loading}:{label:string; value?:string; isPositive?:boolean; loading?:boolean}) {
+  return (
+    <div className="bg-muted/40 rounded-lg p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      {loading ? (
+        <Skeleton className="h-5 w-20 mt-1" />
+      ) : (
+        <div className={`text-lg font-semibold text-card-foreground ${isPositive ? "text-green-400" : ""}`}>{value ?? "—"}</div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- structure overview component with dedicated hooks, lib, and shared folders
- extract Stat, Metric, and EquityArea into shared components
- move active broker, onboarding status, and market highlights logic into custom hooks and re-export utils

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2474e3ec8331a0b6f602665bbedd