### PR TITLE
Refactor settings page into modular components

### DIFF
--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -8,126 +8,25 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Label } from "@/components/ui/label";
-import { Input } from "@/components/ui/input";
-import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { Separator } from "@/components/ui/separator";
-import { Badge } from "@/components/ui/badge";
-import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
-import { Download, Upload, Info, ShieldCheck, BookOpen, Copy, Moon, Sun, Palette, Eye, EyeOff, Settings as SettingsIcon } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { Download, Upload, Copy, Info, ShieldCheck, BookOpen, Palette } from "lucide-react";
 
-/* ---------------------------------- */
-type SettingsState = {
-  appearance: {
-    mode: "system" | "light" | "dark";
-    trueBlack: boolean;
-    accent: "indigo" | "violet" | "blue" | "cyan" | "emerald";
-    density: "cozy" | "compact";
-    animations: boolean;
-  };
-  privacy: {
-    privacyMode: boolean; // masks sensitive info in UI
-    redactAccountIds: boolean;
-    redactOrderIds: boolean;
-    telemetry: boolean; // anonymous usage metrics
-  };
-  info: {
-    env: "Paper" | "Live" | "Sandbox";
-    language: "English" | "Español" | "Deutsch";
-    currency: "USD" | "EUR" | "JPY";
-    notes: string;
-  };
-};
-
-const DEFAULTS: SettingsState = {
-  appearance: {
-    mode: "dark",
-    trueBlack: true,
-    accent: "violet",
-    density: "cozy",
-    animations: true,
-  },
-  privacy: {
-    privacyMode: false,
-    redactAccountIds: true,
-    redactOrderIds: true,
-    telemetry: false,
-  },
-  info: {
-    env: "Paper",
-    language: "English",
-    currency: "USD",
-    notes: "",
-  },
-};
-
-const ACCENT_OPTIONS = [
-  { value: "violet", label: "Violet" },
-  { value: "indigo", label: "Indigo" },
-  { value: "blue", label: "Blue" },
-  { value: "cyan", label: "Cyan" },
-  { value: "emerald", label: "Emerald" },
-] as const;
-
-// Mock app build data — wire to your real env if available
-const APP = {
-  version: "1.7.0",
-  buildId: "2025.08.13-rc2",
-  commit: "c1e9a42",
-  buildDate: "2025-08-13",
-};
+import { useSettings } from "./hooks/useSettings";
+import { DEFAULTS, APP } from "./lib/config";
+import { AppearanceControls } from "./shared/AppearanceControls";
+import { PrivacyToggles } from "./shared/PrivacyToggles";
+import { ReleaseNotesPanel } from "./shared/ReleaseNotesPanel";
+import { AboutPanel } from "./shared/AboutPanel";
 
 export default function SettingsPage() {
-  const [state, setState] = React.useState<SettingsState>(() => {
-    try {
-      const raw = localStorage.getItem("settings");
-      return raw ? JSON.parse(raw) : DEFAULTS;
-    } catch {
-      return DEFAULTS;
-    }
-  });
-
-  // apply UI side effects (theme + accent + density + true-black)
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const root = document.documentElement;
-
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-    const handleSystemThemeChange = (e: MediaQueryListEvent) => {
-      root.classList.toggle('dark', e.matches);
-    };
-    
-    mediaQuery.removeEventListener('change', handleSystemThemeChange);
-    
-    if (state.appearance.mode === 'system') {
-      root.classList.toggle('dark', mediaQuery.matches);
-      mediaQuery.addEventListener('change', handleSystemThemeChange);
-    } else {
-      root.classList.toggle('dark', state.appearance.mode === 'dark');
-    }
-
-    root.dataset.trueBlack = String(state.appearance.trueBlack);
-    root.dataset.accent = state.appearance.accent;
-    root.dataset.density = state.appearance.density;
-    root.dataset.anim = state.appearance.animations ? "on" : "off";
-    root.dataset.privacy = state.privacy.privacyMode ? "on" : "off";
-
-    localStorage.setItem("settings", JSON.stringify(state));
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleSystemThemeChange);
-    };
-  }, [state]);
+  const { state, setState } = useSettings();
 
   const onImport = async (file?: File) => {
     if (!file) return;
     const text = await file.text();
     try {
-      const obj = JSON.parse(text) as SettingsState;
+      const obj = JSON.parse(text);
       setState(obj);
       toast.success("Settings imported successfully.");
     } catch {
@@ -144,18 +43,6 @@ export default function SettingsPage() {
     a.click();
     URL.revokeObjectURL(url);
     toast.success("Settings exported.");
-  };
-
-  const downloadReleaseNotes = () => {
-    const md = `# Release Notes v${APP.version} (${APP.buildDate})\n- New: Brokers page with connection tools and status.\n- New: Overview page with StockBot performance tiles.\n- Improved: True-black theme & animated background blobs.\n- Fix: Order ticket validation edge cases.\n\n## Previous\n${RELEASE_NOTES.map(n=>`### v${n.version} — ${n.date}\n${n.items.map(i=>`- ${i}`).join("\n")}`).join("\n\n")}`;
-    const blob = new Blob([md], { type: "text/markdown" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `RELEASE_NOTES_v${APP.version}.md`;
-    a.click();
-    URL.revokeObjectURL(url);
-    a.remove();
   };
 
   const copy = (txt: string, msg = "Copied to clipboard") => {
@@ -187,130 +74,12 @@ export default function SettingsPage() {
 
         {/* Appearance */}
         <TabsContent value="appearance" className="mt-4">
-          <Card className="ink-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2"><Palette className="h-4 w-4" /> Theme / Look & Feel</CardTitle>
-              <CardDescription>Choose mode, accent, density, and background behavior.</CardDescription>
-            </CardHeader>
-            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {/* Mode */}
-              <div className="space-y-2">
-                <Label>Mode</Label>
-                <div className="flex items-center gap-2">
-                  <Button variant={state.appearance.mode==="light"?"default":"outline"} onClick={()=>setState(s=>({...s, appearance:{...s.appearance, mode:"light"}}))}>
-                    <Sun className="mr-2 h-4 w-4" /> Light
-                  </Button>
-                  <Button variant={state.appearance.mode==="dark"?"default":"outline"} onClick={()=>setState(s=>({...s, appearance:{...s.appearance, mode:"dark"}}))}>
-                    <Moon className="mr-2 h-4 w-4" /> Dark
-                  </Button>
-                  <Button variant={state.appearance.mode==="system"?"default":"outline"} onClick={()=>setState(s=>({...s, appearance:{...s.appearance, mode:"system"}}))}>
-                    <SettingsIcon className="mr-2 h-4 w-4" /> System
-                  </Button>
-                </div>
-              </div>
-
-              {/* True black */}
-              <div className="flex items-center justify-between rounded-md bg-muted/40 p-3">
-                <div>
-                  <Label>True black canvas</Label>
-                  <p className="text-muted-foreground text-xs">Use pure #000 backgrounds for OLED displays.</p>
-                </div>
-                <Switch
-                  checked={state.appearance.trueBlack}
-                  onCheckedChange={(v)=>setState(s=>({...s, appearance:{...s.appearance, trueBlack:Boolean(v)}}))}
-                />
-              </div>
-
-              {/* Accent */}
-              <div className="space-y-2">
-                <Label>Accent</Label>
-                <Select
-                  value={state.appearance.accent}
-                  onValueChange={(v: any)=>setState(s=>({...s, appearance:{...s.appearance, accent:v}}))}
-                >
-                  <SelectTrigger><SelectValue placeholder="Accent color" /></SelectTrigger>
-                  <SelectContent>
-                    {ACCENT_OPTIONS.map(opt => (
-                      <SelectItem key={opt.value} value={opt.value}>
-                        <div className="flex items-center gap-2">
-                          <div className={cn("h-4 w-4 rounded-full", `accent-swatch-${opt.value}`)} />
-                          <span>{opt.label}</span>
-                        </div>
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {/* Density */}
-              <div className="space-y-2">
-                <Label>Density</Label>
-                <Select
-                  value={state.appearance.density}
-                  onValueChange={(v:any)=>setState(s=>({...s, appearance:{...s.appearance, density:v}}))}
-                >
-                  <SelectTrigger><SelectValue placeholder="Density" /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="cozy">Cozy</SelectItem>
-                    <SelectItem value="compact">Compact</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {/* Animations */}
-              <div className="flex items-center justify-between rounded-md bg-muted/40 p-3 md:col-span-2">
-                <div>
-                  <Label>Animations</Label>
-                  <p className="text-muted-foreground text-xs">Disable for maximum performance or to reduce motion.</p>
-                </div>
-                <Switch
-                  checked={state.appearance.animations}
-                  onCheckedChange={(v)=>setState(s=>({...s, appearance:{...s.appearance, animations:Boolean(v)}}))}
-                />
-              </div>
-            </CardContent>
-          </Card>
+          <AppearanceControls state={state} setState={setState} />
         </TabsContent>
 
         {/* Privacy */}
         <TabsContent value="privacy" className="mt-4">
-          <Card className="ink-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2"><ShieldCheck className="h-4 w-4" /> Privacy & Security</CardTitle>
-              <CardDescription>Control redaction and opt in/out of telemetry.</CardDescription>
-            </CardHeader>
-            <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div className="flex items-center justify-between rounded-md bg-muted/40 p-3">
-                <Label>Privacy Mode</Label>
-                <Switch
-                  checked={state.privacy.privacyMode}
-                  onCheckedChange={(v)=>setState(s=>({...s, privacy:{...s.privacy, privacyMode:Boolean(v)}}))}
-                />
-              </div>
-              <div className="flex items-center justify-between rounded-md bg-muted/40 p-3">
-                <Label>Anonymous telemetry</Label>
-                <Switch
-                  checked={state.privacy.telemetry}
-                  onCheckedChange={(v)=>setState(s=>({...s, privacy:{...s.privacy, telemetry:Boolean(v)}}))}
-                />
-              </div>
-
-              {/* Demo: masking preview */}
-              <div className="md:col-span-2 rounded-md bg-background/50 p-3">
-                <div className="flex items-center gap-2 mb-2">
-                  {state.privacy.privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                  <Label>Preview</Label>
-                  <Badge variant="secondary">{state.privacy.privacyMode ? "Masked" : "Visible"}</Badge>
-                </div>
-                <div className="grid grid-cols-2 gap-3 text-sm">
-                  <FieldPreview label="Account" value={mask(state.privacy.privacyMode, "ACC-001234")} />
-                  <FieldPreview label="Order" value={mask(state.privacy.privacyMode, "O-10093")} />
-                  <FieldPreview label="Balance" value={mask(state.privacy.privacyMode, "$127,420")} />
-                  <FieldPreview label="Positions" value={mask(state.privacy.privacyMode, "AAPL 120, NVDA 40")} />
-                </div>
-              </div>
-            </CardContent>
-          </Card>
+          <PrivacyToggles state={state} setState={setState} />
         </TabsContent>
 
         {/* Info */}
@@ -321,9 +90,9 @@ export default function SettingsPage() {
               <CardDescription>Environment & metadata. Copy or export your settings JSON.</CardDescription>
             </CardHeader>
             <CardContent className="grid grid-cols-1 md:grid-cols-3 gap-6">
-              <KeyVal k="Version" v={`v${APP.version}`} onCopy={()=>copy(`v${APP.version}`)} />
-              <KeyVal k="Build" v={APP.buildId} onCopy={()=>copy(APP.buildId)} />
-              <KeyVal k="Commit" v={APP.commit} onCopy={()=>copy(APP.commit)} />
+              <KeyVal k="Version" v={`v${APP.version}`} onCopy={() => copy(`v${APP.version}`)} />
+              <KeyVal k="Build" v={APP.buildId} onCopy={() => copy(APP.buildId)} />
+              <KeyVal k="Commit" v={APP.commit} onCopy={() => copy(APP.commit)} />
               <div className="space-y-2">
                 <Label>Environment</Label>
                 <Select value={state.info.env} onValueChange={(v:any)=>setState(s=>({...s, info:{...s.info, env:v}}))}>
@@ -367,61 +136,8 @@ export default function SettingsPage() {
 
         {/* Release notes + Disclosures */}
         <TabsContent value="about" className="mt-4 space-y-4">
-          <Card className="ink-card">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2"><BookOpen className="h-4 w-4" /> Release Notes</CardTitle>
-              <CardDescription>What’s new and what changed.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <ScrollArea className="h-64 rounded-md bg-background/50 p-3">
-                <div className="space-y-6">
-                  <div>
-                    <div className="flex items-center gap-2">
-                      <Badge>Latest</Badge>
-                      <span className="font-medium">v{APP.version}</span>
-                      <span className="text-muted-foreground text-xs">{APP.buildDate}</span>
-                    </div>
-                    <ul className="mt-2 list-disc pl-5 text-sm">
-                      <li>New: Brokers page with connection tools and status.</li>
-                      <li>New: Overview page with StockBot performance tiles.</li>
-                      <li>Improved: True-black theme & animated background blobs.</li>
-                      <li>Fix: Order ticket validation edge cases.</li>
-                    </ul>
-                  </div>
-                  {RELEASE_NOTES.map((n) => (
-                    <div key={n.version}>
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium">v{n.version}</span>
-                        <span className="text-muted-foreground text-xs">{n.date}</span>
-                      </div>
-                      <ul className="mt-2 list-disc pl-5 text-sm">
-                        {n.items.map((i, idx) => <li key={idx}>{i}</li>)}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              </ScrollArea>
-            </CardContent>
-            <CardFooter>
-              <Button variant="outline" onClick={downloadReleaseNotes}><Download className="mr-2 h-4 w-4" /> Download .md</Button>
-            </CardFooter>
-          </Card>
-
-          <Card className="ink-card">
-            <CardHeader>
-              <CardTitle>Disclosures</CardTitle>
-              <CardDescription>Important information about risks, data, and broker connectivity.</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Accordion type="multiple" className="w-full">
-                <AccordionItem value="risk"><AccordionTrigger>Trading & Market Risk</AccordionTrigger><AccordionContent className="text-sm text-muted-foreground">Trading involves risk of loss. Backtested or simulated performance is hypothetical and may differ from live trading results.</AccordionContent></AccordionItem>
-                <AccordionItem value="data"><AccordionTrigger>Data Sources & Latency</AccordionTrigger><AccordionContent className="text-sm text-muted-foreground">Quotes, fundamentals, and news are provided by third parties and may be delayed or inaccurate. Always verify critical information with your broker.</AccordionContent></AccordionItem>
-                <AccordionItem value="broker"><AccordionTrigger>Broker Integrations</AccordionTrigger><AccordionContent className="text-sm text-muted-foreground">OAuth tokens/keys are stored securely per your backend configuration. Placing live orders requires explicit user action and an active broker connection.</AccordionContent></AccordionItem>
-                <AccordionItem value="privacy"><AccordionTrigger>Privacy Mode</AccordionTrigger><AccordionContent className="text-sm text-muted-foreground">Privacy Mode masks sensitive values in the UI only. It does not scrub server logs or external integrations—configure those separately.</AccordionContent></AccordionItem>
-              </Accordion>
-              <Alert className="mt-4" variant="default"><Info className="h-4 w-4" /><AlertTitle>Reminder</AlertTitle><AlertDescription>Review your jurisdiction’s regulations and your broker’s agreements before enabling live trading.</AlertDescription></Alert>
-            </CardContent>
-          </Card>
+          <ReleaseNotesPanel />
+          <AboutPanel />
         </TabsContent>
       </Tabs>
     </div>
@@ -444,23 +160,3 @@ function KeyVal({ k, v, onCopy }: { k: string; v: string; onCopy?: () => void })
     </div>
   );
 }
-
-function FieldPreview({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-md bg-muted/40 p-3">
-      <div className="text-xs text-muted-foreground">{label}</div>
-      <div className="font-mono text-sm">{value}</div>
-    </div>
-  );
-}
-
-function mask(on: boolean, raw: string) {
-  if (!on) return raw;
-  return raw.replace(/[A-Za-z0-9]/g, (m, i) => (i % 2 === 0 ? "•" : m));
-}
-
-/* Past releases (mock). Replace with your CHANGELOG feed if available. */
-const RELEASE_NOTES = [
-  { version: "1.6.3", date: "2025-08-05", items: ["Add DOM ladder widget", "Portfolio filters & export", "Improve blotter performance"] },
-  { version: "1.6.0", date: "2025-07-28", items: ["Initial StockBot runs tab", "Backtest report export", "Risk panel (VaR/ES)"] },
-];

--- a/frontend/src/components/settings/hooks/useSettings.ts
+++ b/frontend/src/components/settings/hooks/useSettings.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import * as React from "react";
+import { DEFAULTS, SettingsState } from "../lib/config";
+
+export function useSettings() {
+  const [state, setState] = React.useState<SettingsState>(() => {
+    try {
+      const raw = localStorage.getItem("settings");
+      return raw ? JSON.parse(raw) : DEFAULTS;
+    } catch {
+      return DEFAULTS;
+    }
+  });
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const root = document.documentElement;
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const handleSystemThemeChange = (e: MediaQueryListEvent) => {
+      root.classList.toggle("dark", e.matches);
+    };
+
+    mediaQuery.removeEventListener("change", handleSystemThemeChange);
+
+    if (state.appearance.mode === "system") {
+      root.classList.toggle("dark", mediaQuery.matches);
+      mediaQuery.addEventListener("change", handleSystemThemeChange);
+    } else {
+      root.classList.toggle("dark", state.appearance.mode === "dark");
+    }
+
+    root.dataset.trueBlack = String(state.appearance.trueBlack);
+    root.dataset.accent = state.appearance.accent;
+    root.dataset.density = state.appearance.density;
+    root.dataset.anim = state.appearance.animations ? "on" : "off";
+    root.dataset.privacy = state.privacy.privacyMode ? "on" : "off";
+
+    localStorage.setItem("settings", JSON.stringify(state));
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleSystemThemeChange);
+    };
+  }, [state]);
+
+  return { state, setState } as const;
+}

--- a/frontend/src/components/settings/lib/config.ts
+++ b/frontend/src/components/settings/lib/config.ts
@@ -1,0 +1,63 @@
+export type SettingsState = {
+  appearance: {
+    mode: "system" | "light" | "dark";
+    trueBlack: boolean;
+    accent: "indigo" | "violet" | "blue" | "cyan" | "emerald";
+    density: "cozy" | "compact";
+    animations: boolean;
+  };
+  privacy: {
+    privacyMode: boolean;
+    redactAccountIds: boolean;
+    redactOrderIds: boolean;
+    telemetry: boolean;
+  };
+  info: {
+    env: "Paper" | "Live" | "Sandbox";
+    language: "English" | "Español" | "Deutsch";
+    currency: "USD" | "EUR" | "JPY";
+    notes: string;
+  };
+};
+
+export const DEFAULTS: SettingsState = {
+  appearance: {
+    mode: "dark",
+    trueBlack: true,
+    accent: "violet",
+    density: "cozy",
+    animations: true,
+  },
+  privacy: {
+    privacyMode: false,
+    redactAccountIds: true,
+    redactOrderIds: true,
+    telemetry: false,
+  },
+  info: {
+    env: "Paper",
+    language: "English",
+    currency: "USD",
+    notes: "",
+  },
+};
+
+export const ACCENT_OPTIONS = [
+  { value: "violet", label: "Violet" },
+  { value: "indigo", label: "Indigo" },
+  { value: "blue", label: "Blue" },
+  { value: "cyan", label: "Cyan" },
+  { value: "emerald", label: "Emerald" },
+] as const;
+
+export const APP = {
+  version: "1.7.0",
+  buildId: "2025.08.13-rc2",
+  commit: "c1e9a42",
+  buildDate: "2025-08-13",
+};
+
+export const RELEASE_NOTES = [
+  { version: "1.6.3", date: "2025-08-05", items: ["Add DOM ladder widget", "Portfolio filters & export", "Improve blotter performance"] },
+  { version: "1.6.0", date: "2025-07-28", items: ["Initial StockBot runs tab", "Backtest report export", "Risk panel (VaR/ES)"] },
+];

--- a/frontend/src/components/settings/shared/AboutPanel.tsx
+++ b/frontend/src/components/settings/shared/AboutPanel.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Info } from "lucide-react";
+
+export function AboutPanel() {
+  return (
+    <Card className="ink-card">
+      <CardHeader>
+        <CardTitle>Disclosures</CardTitle>
+        <CardDescription>Important information about risks, data, and broker connectivity.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Accordion type="multiple" className="w-full">
+          <AccordionItem value="risk">
+            <AccordionTrigger>Trading & Market Risk</AccordionTrigger>
+            <AccordionContent className="text-sm text-muted-foreground">Trading involves risk of loss. Backtested or simulated performance is hypothetical and may differ from live trading results.</AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="data">
+            <AccordionTrigger>Data Sources & Latency</AccordionTrigger>
+            <AccordionContent className="text-sm text-muted-foreground">Quotes, fundamentals, and news are provided by third parties and may be delayed or inaccurate. Always verify critical information with your broker.</AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="broker">
+            <AccordionTrigger>Broker Integrations</AccordionTrigger>
+            <AccordionContent className="text-sm text-muted-foreground">OAuth tokens/keys are stored securely per your backend configuration. Placing live orders requires explicit user action and an active broker connection.</AccordionContent>
+          </AccordionItem>
+          <AccordionItem value="privacy">
+            <AccordionTrigger>Privacy Mode</AccordionTrigger>
+            <AccordionContent className="text-sm text-muted-foreground">Privacy Mode masks sensitive values in the UI only. It does not scrub server logs or external integrations—configure those separately.</AccordionContent>
+          </AccordionItem>
+        </Accordion>
+        <Alert className="mt-4" variant="default">
+          <Info className="h-4 w-4" />
+          <AlertTitle>Reminder</AlertTitle>
+          <AlertDescription>Review your jurisdiction’s regulations and your broker’s agreements before enabling live trading.</AlertDescription>
+        </Alert>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/shared/AppearanceControls.tsx
+++ b/frontend/src/components/settings/shared/AppearanceControls.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { Palette, Sun, Moon, Settings as SettingsIcon } from "lucide-react";
+import { SettingsState, ACCENT_OPTIONS } from "../lib/config";
+
+interface Props {
+  state: SettingsState;
+  setState: React.Dispatch<React.SetStateAction<SettingsState>>;
+}
+
+export function AppearanceControls({ state, setState }: Props) {
+  return (
+    <Card className="ink-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><Palette className="h-4 w-4" /> Theme / Look & Feel</CardTitle>
+        <CardDescription>Choose mode, accent, density, and background behavior.</CardDescription>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {/* Mode */}
+        <div className="space-y-2">
+          <Label>Mode</Label>
+          <div className="flex items-center gap-2">
+            <Button variant={state.appearance.mode === "light" ? "default" : "outline"} onClick={() => setState(s => ({ ...s, appearance: { ...s.appearance, mode: "light" } }))}>
+              <Sun className="mr-2 h-4 w-4" /> Light
+            </Button>
+            <Button variant={state.appearance.mode === "dark" ? "default" : "outline"} onClick={() => setState(s => ({ ...s, appearance: { ...s.appearance, mode: "dark" } }))}>
+              <Moon className="mr-2 h-4 w-4" /> Dark
+            </Button>
+            <Button variant={state.appearance.mode === "system" ? "default" : "outline"} onClick={() => setState(s => ({ ...s, appearance: { ...s.appearance, mode: "system" } }))}>
+              <SettingsIcon className="mr-2 h-4 w-4" /> System
+            </Button>
+          </div>
+        </div>
+
+        {/* True black */}
+        <div className="flex items-center justify-between rounded-md bg-muted/40 p-3">
+          <div>
+            <Label>True black canvas</Label>
+            <p className="text-muted-foreground text-xs">Use pure #000 backgrounds for OLED displays.</p>
+          </div>
+          <Switch
+            checked={state.appearance.trueBlack}
+            onCheckedChange={(v) => setState(s => ({ ...s, appearance: { ...s.appearance, trueBlack: Boolean(v) } }))}
+          />
+        </div>
+
+        {/* Accent */}
+        <div className="space-y-2">
+          <Label>Accent</Label>
+          <Select
+            value={state.appearance.accent}
+            onValueChange={(v) => setState(s => ({ ...s, appearance: { ...s.appearance, accent: v as any } }))}
+          >
+            <SelectTrigger><SelectValue placeholder="Accent color" /></SelectTrigger>
+            <SelectContent>
+              {ACCENT_OPTIONS.map(opt => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  <div className="flex items-center gap-2">
+                    <div className={cn("h-4 w-4 rounded-full", `accent-swatch-${opt.value}`)} />
+                    <span>{opt.label}</span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Density */}
+        <div className="space-y-2">
+          <Label>Density</Label>
+          <Select
+            value={state.appearance.density}
+            onValueChange={(v) => setState(s => ({ ...s, appearance: { ...s.appearance, density: v as any } }))}
+          >
+            <SelectTrigger><SelectValue placeholder="Density" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="cozy">Cozy</SelectItem>
+              <SelectItem value="compact">Compact</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Animations */}
+        <div className="flex items-center justify-between rounded-md bg-muted/40 p-3 md:col-span-2">
+          <div>
+            <Label>Animations</Label>
+            <p className="text-muted-foreground text-xs">Disable for maximum performance or to reduce motion.</p>
+          </div>
+          <Switch
+            checked={state.appearance.animations}
+            onCheckedChange={(v) => setState(s => ({ ...s, appearance: { ...s.appearance, animations: Boolean(v) } }))}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/settings/shared/PrivacyToggles.tsx
+++ b/frontend/src/components/settings/shared/PrivacyToggles.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import { Eye, EyeOff, ShieldCheck } from "lucide-react";
+import { SettingsState } from "../lib/config";
+
+interface Props {
+  state: SettingsState;
+  setState: React.Dispatch<React.SetStateAction<SettingsState>>;
+}
+
+export function PrivacyToggles({ state, setState }: Props) {
+  return (
+    <Card className="ink-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><ShieldCheck className="h-4 w-4" /> Privacy & Security</CardTitle>
+        <CardDescription>Control redaction and opt in/out of telemetry.</CardDescription>
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="flex items-center justify-between rounded-md bg-muted/40 p-3">
+          <Label>Privacy Mode</Label>
+          <Switch
+            checked={state.privacy.privacyMode}
+            onCheckedChange={(v) => setState(s => ({ ...s, privacy: { ...s.privacy, privacyMode: Boolean(v) } }))}
+          />
+        </div>
+        <div className="flex items-center justify-between rounded-md bg-muted/40 p-3">
+          <Label>Anonymous telemetry</Label>
+          <Switch
+            checked={state.privacy.telemetry}
+            onCheckedChange={(v) => setState(s => ({ ...s, privacy: { ...s.privacy, telemetry: Boolean(v) } }))}
+          />
+        </div>
+
+        {/* Demo: masking preview */}
+        <div className="md:col-span-2 rounded-md bg-background/50 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            {state.privacy.privacyMode ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+            <Label>Preview</Label>
+            <Badge variant="secondary">{state.privacy.privacyMode ? "Masked" : "Visible"}</Badge>
+          </div>
+          <div className="grid grid-cols-2 gap-3 text-sm">
+            <FieldPreview label="Account" value={mask(state.privacy.privacyMode, "ACC-001234")} />
+            <FieldPreview label="Order" value={mask(state.privacy.privacyMode, "O-10093")} />
+            <FieldPreview label="Balance" value={mask(state.privacy.privacyMode, "$127,420")} />
+            <FieldPreview label="Positions" value={mask(state.privacy.privacyMode, "AAPL 120, NVDA 40")} />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FieldPreview({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md bg-muted/40 p-3">
+      <div className="text-xs text-muted-foreground">{label}</div>
+      <div className="font-mono text-sm">{value}</div>
+    </div>
+  );
+}
+
+function mask(on: boolean, raw: string) {
+  if (!on) return raw;
+  return raw.replace(/[A-Za-z0-9]/g, (m, i) => (i % 2 === 0 ? "•" : m));
+}

--- a/frontend/src/components/settings/shared/ReleaseNotesPanel.tsx
+++ b/frontend/src/components/settings/shared/ReleaseNotesPanel.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { BookOpen, Download } from "lucide-react";
+import { APP, RELEASE_NOTES } from "../lib/config";
+
+export function ReleaseNotesPanel() {
+  const downloadReleaseNotes = () => {
+    const md = `# Release Notes v${APP.version} (${APP.buildDate})\n- New: Brokers page with connection tools and status.\n- New: Overview page with StockBot performance tiles.\n- Improved: True-black theme & animated background blobs.\n- Fix: Order ticket validation edge cases.\n\n## Previous\n${RELEASE_NOTES.map(n=>`### v${n.version} — ${n.date}\n${n.items.map(i=>`- ${i}`).join("\n")}`).join("\n\n")}`;
+    const blob = new Blob([md], { type: "text/markdown" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `RELEASE_NOTES_v${APP.version}.md`;
+    a.click();
+    URL.revokeObjectURL(url);
+    a.remove();
+  };
+
+  return (
+    <Card className="ink-card">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2"><BookOpen className="h-4 w-4" /> Release Notes</CardTitle>
+        <CardDescription>What’s new and what changed.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ScrollArea className="h-64 rounded-md bg-background/50 p-3">
+          <div className="space-y-6">
+            <div>
+              <div className="flex items-center gap-2">
+                <Badge>Latest</Badge>
+                <span className="font-medium">v{APP.version}</span>
+                <span className="text-muted-foreground text-xs">{APP.buildDate}</span>
+              </div>
+              <ul className="mt-2 list-disc pl-5 text-sm">
+                <li>New: Brokers page with connection tools and status.</li>
+                <li>New: Overview page with StockBot performance tiles.</li>
+                <li>Improved: True-black theme & animated background blobs.</li>
+                <li>Fix: Order ticket validation edge cases.</li>
+              </ul>
+            </div>
+            {RELEASE_NOTES.map((n) => (
+              <div key={n.version}>
+                <div className="flex items-center gap-2">
+                  <span className="font-medium">v{n.version}</span>
+                  <span className="text-muted-foreground text-xs">{n.date}</span>
+                </div>
+                <ul className="mt-2 list-disc pl-5 text-sm">
+                  {n.items.map((i, idx) => <li key={idx}>{i}</li>)}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </ScrollArea>
+      </CardContent>
+      <CardFooter>
+        <Button variant="outline" onClick={downloadReleaseNotes}><Download className="mr-2 h-4 w-4" /> Download .md</Button>
+      </CardFooter>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- split settings page into appearance, privacy, release notes, and about panels
- add `useSettings` hook to centralize theme and persistence
- extract settings constants into dedicated config module

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad247496408331b6f61ed1dbed7afe