### PR TITLE
feat: centralize frontend http helpers

### DIFF
--- a/frontend/src/api/alpaca.ts
+++ b/frontend/src/api/alpaca.ts
@@ -1,32 +1,17 @@
-import axios from 'axios';
-
-
 export interface ConnectAlpacaPayload {
   app_key: string;
   app_secret: string;
   mode: 'paper' | 'live';
 }
-// Base config for authenticated requests
-const getAuthConfig = () => {
-  return {
-    withCredentials: true, // send cookie
-    headers: { 'Content-Type': 'application/json' },
-  };
-};
+import { fetchJSON, postJSON } from '@/api/http';
 /**
  * Connects the user's Alpaca account by sending API key/secret to the backend.
  * The backend should validate credentials before saving them.
  */
 export async function connectAlpaca(payload: ConnectAlpacaPayload) {
-  const url = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/alpaca/connect`; 
-  console.log('Connecting to Alpaca URL:', url);
-
-  const res = await axios.post(url, payload, getAuthConfig());
-  return res.data;
+  return postJSON('/api/alpaca/connect', payload);
 }
 
 export const checkAlpacaCredentials = async () => {
-  const url = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/alpaca/status`; 
-  const res = await axios.get(url, getAuthConfig());
-  return res.data;
+  return fetchJSON('/api/alpaca/status');
 };

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,9 +1,7 @@
-// utils/http.ts
 import axios, { AxiosError } from "axios";
 
 /** Prefer NEXT_PUBLIC_BACKEND_URL; fall back to relative paths if unset */
-const BACKEND_BASE =
-  process.env.NEXT_PUBLIC_BACKEND_URL;
+export const BACKEND_BASE = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 /** Absolute if starts with http(s) or protocol-relative (//host) */
 const isAbsolute = (u: string) => /^https?:\/\//i.test(u) || /^\/\//.test(u);
@@ -16,7 +14,8 @@ const join = (base: string | undefined | null, path: string) => {
 };
 
 /** If BACKEND_BASE is empty, return a relative URL so same-origin works */
-const buildUrl = (u: string) => (isAbsolute(u) ? u : (BACKEND_BASE ? join(BACKEND_BASE, u) : u));
+export const buildUrl = (u: string) =>
+  isAbsolute(u) ? u : BACKEND_BASE ? join(BACKEND_BASE, u) : u;
 
 function toReadableError(err: unknown): Error {
   if (axios.isAxiosError(err)) {
@@ -32,7 +31,6 @@ function toReadableError(err: unknown): Error {
 export async function fetchJSON<T = any>(url: string): Promise<T> {
   try {
     const full = buildUrl(url);
-    // console.debug("[http] GET", full);
     const { data } = await axios.get<T>(full, {
       withCredentials: true,
       headers: { "Cache-Control": "no-store" },
@@ -46,7 +44,6 @@ export async function fetchJSON<T = any>(url: string): Promise<T> {
 export async function postJSON<T = any>(url: string, body: any): Promise<T> {
   try {
     const full = buildUrl(url);
-    // console.debug("[http] POST", full, body);
     const { data } = await axios.post<T>(full, body, {
       withCredentials: true,
       headers: { "Content-Type": "application/json" },
@@ -56,3 +53,4 @@ export async function postJSON<T = any>(url: string, body: any): Promise<T> {
     throw toReadableError(err);
   }
 }
+

--- a/frontend/src/api/jarvisApi.ts
+++ b/frontend/src/api/jarvisApi.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { fetchJSON, postJSON } from '@/api/http';
 
 
 type UserPreferences = {
@@ -22,57 +22,26 @@ export type DomAction =
   | { op: "scroll"; to?: "top" | "bottom"; y?: number };
 
 export async function planPageEdit(goal: string): Promise<{ actions: DomAction[] }> {
-  const res = await axios.post(
-    `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/edit/plan`,
-    { goal },
-    { withCredentials: true, headers: { "Content-Type": "application/json" } }
-  );
-  return res.data;
+  return postJSON('/api/jarvis/edit/plan', { goal });
 }
 
 // Submit text prompt to Jarvis
 export const askJarvis = async (prompt: string, user: User) => {
   const model = user?.preferences?.model || 'llama3';
   const format = user?.preferences?.format || 'markdown';
-
-  const res = await axios.post(
-    `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/ask`,
-    { prompt, model, format },
-    {
-      withCredentials: true, // send cookie
-      headers: { 'Content-Type': 'application/json' },
-    }
-  );
-
-  return res.data;
+  return postJSON('/api/jarvis/ask', { prompt, model, format });
 };
 
-
-// Base config for authenticated requests
-const getAuthConfig = () => {
-  return {
-    withCredentials: true, // send cookie
-    headers: { 'Content-Type': 'application/json' },
-  };
-};
 
 export async function getSchwabPortfolioData() {
-  
-  const response = await axios.get(
-    `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/portfolio`,
-    getAuthConfig()
-  );
-  return response.data;
+  return fetchJSON('/api/jarvis/portfolio');
 }
 
 export async function fetchAvailableModels(): Promise<string[]> {
   try {
-    const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/models`,
-      getAuthConfig()
-    );
-    console.log(response.data);
-    return response.data;
+    const data = await fetchJSON<string[]>('/api/jarvis/models');
+    console.log(data);
+    return data;
   } catch (error) {
     console.error('Error fetching models:', error);
     return [];

--- a/frontend/src/api/schwab.ts
+++ b/frontend/src/api/schwab.ts
@@ -1,33 +1,16 @@
-import axios from 'axios';
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+import { fetchJSON, postJSON } from '@/api/http';
 
 export async function saveSchwabCredentials(appKey: string, appSecret: string) {
   if (!appKey || !appSecret) {
     throw new Error('Missing app key or app secret.');
   }
 
-  const res = await axios.post(
-    `${BACKEND_URL}/api/schwab/set-credentials`,
-    { app_key: appKey, app_secret: appSecret },
-    { 
-        withCredentials: true,
-        headers: { 'Content-Type': 'application/json' },
-     }
-    
-  );
-
-  return res.data; // { success: true }
+  return postJSON('/api/schwab/set-credentials', {
+    app_key: appKey,
+    app_secret: appSecret,
+  });
 }
 
 export async function checkSchwabCredentials() {
-  const res = await axios.get(
-    `${BACKEND_URL}/api/schwab/check-credentials`,
-    { 
-        withCredentials: true,
-        headers: { 'Content-Type': 'application/json' },
-     }
-  );
-
-  return res.data; // { exists: boolean }
+  return fetchJSON('/api/schwab/check-credentials');
 }

--- a/frontend/src/api/stockbot.ts
+++ b/frontend/src/api/stockbot.ts
@@ -1,15 +1,5 @@
 import axios from "axios";
-
-const BASE = process.env.NEXT_PUBLIC_BACKEND_URL;
-
-const join = (base: string | undefined | null, path: string) => {
-  const b = (base ?? "").replace(/\/+$/, "");
-  const p = (path ?? "").replace(/^\/+/, "");
-  return b ? `${b}/${p}` : `/${p}`;
-};
-
-const buildUrl = (u: string) =>
-  /^https?:\/\//i.test(u) || /^\/\//.test(u) ? u : BASE ? join(BASE, u) : u;
+import { buildUrl, fetchJSON } from "@/api/http";
 
 export async function uploadPolicy(file: File) {
   const form = new FormData();
@@ -32,17 +22,11 @@ export async function downloadRunBundle(runId: string, includeModel = true): Pro
   return data as Blob;
 }
 
-export async function getAiInsights() {
-  const { data } = await axios.get(buildUrl("/api/stockbot/insights"), {
-    withCredentials: true,
-  });
-  return data as { insights: string[] };
+export function getAiInsights() {
+  return fetchJSON<{ insights: string[] }>("/api/stockbot/insights");
 }
 
-export async function getMarketHighlights() {
-  const { data } = await axios.get(buildUrl("/api/stockbot/highlights"), {
-    withCredentials: true,
-  });
-  return data as { highlights: string };
+export function getMarketHighlights() {
+  return fetchJSON<{ highlights: string }>("/api/stockbot/highlights");
 }
 

--- a/frontend/src/components/Auth/SchwabAuth.tsx
+++ b/frontend/src/components/Auth/SchwabAuth.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { saveSchwabCredentials, checkSchwabCredentials } from '@/api/schwab';
-import axios from 'axios';
+import { postJSON } from '@/api/http';
 
 interface Props {
   onConnected: () => void;
@@ -75,11 +75,7 @@ export default function SchwabAuth({ onConnected }: Props) {
         return;
       }
 
-      await axios.post(
-        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/schwab/authorize`,
-        { code },
-        { withCredentials: true }
-      );
+      await postJSON('/api/schwab/authorize', { code });
 
       setStatus('success');
       setMessage('Success! Tokens stored.');

--- a/frontend/src/components/Stockbot/CompareRuns.tsx
+++ b/frontend/src/components/Stockbot/CompareRuns.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { fetchJSON } from "./lib/api";
+import { fetchJSON } from "@/api/http";
 import { RunSummary, Metrics, RunArtifacts } from "./lib/types";
 import { formatPct, formatSigned } from "./lib/formats";
 

--- a/frontend/src/components/Stockbot/Dashboard.tsx
+++ b/frontend/src/components/Stockbot/Dashboard.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { fetchJSON } from "./lib/api";
+import { fetchJSON } from "@/api/http";
 import { RunSummary } from "./lib/types";
 import StatusChip from "./shared/StatusChip";
 import {

--- a/frontend/src/components/Stockbot/NewBacktest.tsx
+++ b/frontend/src/components/Stockbot/NewBacktest.tsx
@@ -6,7 +6,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { postJSON } from "./lib/api";
+import { postJSON } from "@/api/http";
 import { addRecentRun } from "./lib/runs";
 
 export default function NewBacktest({

--- a/frontend/src/components/Stockbot/NewTraining.tsx
+++ b/frontend/src/components/Stockbot/NewTraining.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { fetchJSON, postJSON } from "./lib/api";
+import { fetchJSON, postJSON } from "@/api/http";
 import { addRecentRun } from "./lib/runs";
 import type { JobStatusResponse, RunArtifacts } from "./lib/types";
 

--- a/frontend/src/hooks/useAlpacaStatus.ts
+++ b/frontend/src/hooks/useAlpacaStatus.ts
@@ -1,6 +1,6 @@
 // /hooks/useAlpacaStatus.ts
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import { fetchJSON } from '@/api/http';
 
 export function useAlpacaStatus() {
   const [status, setStatus] = useState<boolean | null>(null);
@@ -8,11 +8,10 @@ export function useAlpacaStatus() {
   useEffect(() => {
     const checkStatus = async () => {
       try {
-        const res = await axios.get<{ connected: boolean }>(
-          `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/alpaca/account`,
-          { withCredentials: true }
+        const res = await fetchJSON<{ connected: boolean }>(
+          `/api/alpaca/account`
         );
-        setStatus(res.data.connected);
+        setStatus(res.connected);
       } catch {
         setStatus(false);
       }

--- a/frontend/src/hooks/useSchwabStatus.ts
+++ b/frontend/src/hooks/useSchwabStatus.ts
@@ -1,17 +1,14 @@
 import { useEffect, useState } from 'react';
-import axios from 'axios';
+import { fetchJSON } from '@/api/http';
 
 export function useSchwabStatus() {
   const [connected, setConnected] = useState<boolean | null>(null);
 
   useEffect(() => {
-    axios
-      .get(`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/schwab/account`, {
-        withCredentials: true, // Send secure cookie automatically
-      })
+    fetchJSON<{ connected: boolean }>(`/api/schwab/account`)
       .then((res) => {
-        console.log('[Schwab] Response:', res.data);
-        setConnected(res?.data?.connected === true);
+        console.log('[Schwab] Response:', res);
+        setConnected(res?.connected === true);
       })
       .catch((err) => {
         console.error('[Schwab] Error:', err);


### PR DESCRIPTION
## Summary
- add shared `fetchJSON`/`postJSON` helpers in `src/api/http`
- refactor Stockbot components and API modules to use centralized HTTP utilities

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2473ffbc8331958d2cea81ac6e79