### PR TITLE
refactor: centralize HTTP helpers

### DIFF
--- a/frontend/src/api/alpaca.ts
+++ b/frontend/src/api/alpaca.ts
@@ -1,32 +1,19 @@
-import axios from 'axios';
-
+import { fetchJSON, postJSON } from '@/api/http';
 
 export interface ConnectAlpacaPayload {
   app_key: string;
   app_secret: string;
   mode: 'paper' | 'live';
 }
-// Base config for authenticated requests
-const getAuthConfig = () => {
-  return {
-    withCredentials: true, // send cookie
-    headers: { 'Content-Type': 'application/json' },
-  };
-};
+
 /**
  * Connects the user's Alpaca account by sending API key/secret to the backend.
  * The backend should validate credentials before saving them.
  */
 export async function connectAlpaca(payload: ConnectAlpacaPayload) {
-  const url = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/alpaca/connect`; 
-  console.log('Connecting to Alpaca URL:', url);
-
-  const res = await axios.post(url, payload, getAuthConfig());
-  return res.data;
+  return postJSON('/api/alpaca/connect', payload);
 }
 
 export const checkAlpacaCredentials = async () => {
-  const url = `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/alpaca/status`; 
-  const res = await axios.get(url, getAuthConfig());
-  return res.data;
+  return fetchJSON('/api/alpaca/status');
 };

--- a/frontend/src/api/brokerService.ts
+++ b/frontend/src/api/brokerService.ts
@@ -1,44 +1,23 @@
-// services/brokerService.ts
-import axios from 'axios';
+import { fetchJSON, postJSON } from '@/api/http';
 import { setUserPreferences } from '@/api/client';
-
-
-// Set the base API URL for brokers
-const API_BASE = process.env.NEXT_PUBLIC_BACKEND_URL;
 
 export const setActiveBroker = async (broker: string) => {
   return setUserPreferences({ activeBroker: broker });
 };
 
-
 export async function disconnectBroker(broker: string) {
-  return axios.post(
-    `${API_BASE}/api/${broker}/disconnect`,
-    {},
-    { withCredentials: true }
-  );
+  return postJSON(`/api/${broker}/disconnect`, {});
 }
 
 export async function getActiveApiPortfolioData() {
   try {
-    const res = await axios.get(
-        `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/broker/portfolio`,
-        { 
-            withCredentials: true,
-            headers: { 'Content-Type': 'application/json' },
-            timeout: 10000, // ✅ 10 second timeout to prevent hanging requests
-        }
-    );
-    
-   
-    return res.data;
+    return await fetchJSON(`/api/broker/portfolio`);
   } catch (error: any) {
     console.error('❌ Error fetching active broker portfolio:', error);
-    
-    // ✅ Re-throw with more specific error info
-    if (error.response?.status === 500) {
+    const status = (error as any).status;
+    if (status === 500) {
       throw new Error('Server error: Unable to fetch portfolio data. Check if active broker is connected.');
-    } else if (error.response?.status === 400) {
+    } else if (status === 400) {
       throw new Error('No active broker set. Please select and connect a broker first.');
     } else {
       throw new Error('Failed to fetch portfolio data');
@@ -49,19 +28,10 @@ export async function getActiveApiPortfolioData() {
 // Add this function to check actual broker connection status
 export async function checkBrokerConnectionStatus(brokerId: string) {
   try {
-    const response = await axios.get(
-      `${API_BASE}/api/${brokerId}/status`,
-      { 
-        withCredentials: true,
-        headers: { 'Content-Type': 'application/json' }
-       }
-    );
-    
-    // Return the status from the API response
-    return response.data.status || 'disconnected';
+    const { status } = await fetchJSON<{ status: string }>(`/api/${brokerId}/status`);
+    return status || 'disconnected';
   } catch (error) {
     console.error(`Failed to check connection status for ${brokerId}:`, error);
-    // If we can't check status, assume disconnected
     return 'disconnected';
   }
 }
@@ -74,9 +44,9 @@ export async function pollBrokerConnectionStatus(
   let last = 'disconnected';
 
   for (let i = 0; i < retries; i++) {
-    last = await checkBrokerConnectionStatus(brokerId); // <-- already returns 'disconnected' on error
+    last = await checkBrokerConnectionStatus(brokerId);
     if (last === 'connected') return 'connected';
     await new Promise((r) => setTimeout(r, intervalMs));
   }
-  return last; // 'disconnected' if never flipped
+  return last;
 }

--- a/frontend/src/api/jarvisApi.ts
+++ b/frontend/src/api/jarvisApi.ts
@@ -1,5 +1,4 @@
-import axios from 'axios';
-
+import { fetchJSON, postJSON } from '@/api/http';
 
 type UserPreferences = {
   model?: string;
@@ -22,90 +21,45 @@ export type DomAction =
   | { op: "scroll"; to?: "top" | "bottom"; y?: number };
 
 export async function planPageEdit(goal: string): Promise<{ actions: DomAction[] }> {
-  const res = await axios.post(
-    `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/edit/plan`,
-    { goal },
-    { withCredentials: true, headers: { "Content-Type": "application/json" } }
-  );
-  return res.data;
+  return postJSON(`/api/jarvis/edit/plan`, { goal });
 }
 
 // Submit text prompt to Jarvis
 export const askJarvis = async (prompt: string, user: User) => {
   const model = user?.preferences?.model || 'llama3';
   const format = user?.preferences?.format || 'markdown';
-
-  const res = await axios.post(
-    `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/ask`,
-    { prompt, model, format },
-    {
-      withCredentials: true, // send cookie
-      headers: { 'Content-Type': 'application/json' },
-    }
-  );
-
-  return res.data;
-};
-
-
-// Base config for authenticated requests
-const getAuthConfig = () => {
-  return {
-    withCredentials: true, // send cookie
-    headers: { 'Content-Type': 'application/json' },
-  };
+  return postJSON(`/api/jarvis/ask`, { prompt, model, format });
 };
 
 export async function getSchwabPortfolioData() {
-  
-  const response = await axios.get(
-    `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/portfolio`,
-    getAuthConfig()
-  );
-  return response.data;
+  return fetchJSON(`/api/jarvis/portfolio`);
 }
 
 export async function fetchAvailableModels(): Promise<string[]> {
   try {
-    const response = await axios.get(
-      `${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis/models`,
-      getAuthConfig()
-    );
-    console.log(response.data);
-    return response.data;
+    return await fetchJSON(`/api/jarvis/models`);
   } catch (error) {
     console.error('Error fetching models:', error);
     return [];
   }
 }
 
-
-
 // Send recorded audio to Jarvis for STT → LLM → TTS
-
 export function connectJarvisWebSocket(): WebSocket {
-  // Ensure we switch to ws:// or wss:// based on environment
   const baseUrl = process.env.NEXT_PUBLIC_BACKEND_URL || "";
   const wsUrl = baseUrl
-    .replace(/^http/, "ws") // convert http/https to ws/wss
-    .replace(/\/$/, "");    // remove trailing slash if any
-
-  // Full endpoint for Jarvis voice streaming
+    .replace(/^http/, "ws")
+    .replace(/\/$/, "");
   const fullUrl = `${wsUrl}/api/jarvis/voice/ws`;
-
   const ws = new WebSocket(fullUrl);
-
   ws.onopen = () => {
     console.log("🔌 Connected to Jarvis voice WebSocket");
   };
-
   ws.onerror = (err) => {
     console.error("WebSocket error:", err);
   };
-
   ws.onclose = (e) => {
     console.log(`Jarvis voice WebSocket closed: code=${e.code} reason=${e.reason}`);
   };
-
   return ws;
 }

--- a/frontend/src/api/schwab.ts
+++ b/frontend/src/api/schwab.ts
@@ -1,33 +1,15 @@
-import axios from 'axios';
-
-const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL;
+import { fetchJSON, postJSON } from '@/api/http';
 
 export async function saveSchwabCredentials(appKey: string, appSecret: string) {
   if (!appKey || !appSecret) {
     throw new Error('Missing app key or app secret.');
   }
-
-  const res = await axios.post(
-    `${BACKEND_URL}/api/schwab/set-credentials`,
-    { app_key: appKey, app_secret: appSecret },
-    { 
-        withCredentials: true,
-        headers: { 'Content-Type': 'application/json' },
-     }
-    
-  );
-
-  return res.data; // { success: true }
+  return postJSON('/api/schwab/set-credentials', {
+    app_key: appKey,
+    app_secret: appSecret,
+  });
 }
 
 export async function checkSchwabCredentials() {
-  const res = await axios.get(
-    `${BACKEND_URL}/api/schwab/check-credentials`,
-    { 
-        withCredentials: true,
-        headers: { 'Content-Type': 'application/json' },
-     }
-  );
-
-  return res.data; // { exists: boolean }
+  return fetchJSON('/api/schwab/check-credentials');
 }

--- a/frontend/src/api/stockbot.ts
+++ b/frontend/src/api/stockbot.ts
@@ -1,15 +1,5 @@
 import axios from "axios";
-
-const BASE = process.env.NEXT_PUBLIC_BACKEND_URL;
-
-const join = (base: string | undefined | null, path: string) => {
-  const b = (base ?? "").replace(/\/+$/, "");
-  const p = (path ?? "").replace(/^\/+/, "");
-  return b ? `${b}/${p}` : `/${p}`;
-};
-
-const buildUrl = (u: string) =>
-  /^https?:\/\//i.test(u) || /^\/\//.test(u) ? u : BASE ? join(BASE, u) : u;
+import { buildUrl, fetchJSON } from "@/api/http";
 
 export async function uploadPolicy(file: File) {
   const form = new FormData();
@@ -33,16 +23,9 @@ export async function downloadRunBundle(runId: string, includeModel = true): Pro
 }
 
 export async function getAiInsights() {
-  const { data } = await axios.get(buildUrl("/api/stockbot/insights"), {
-    withCredentials: true,
-  });
-  return data as { insights: string[] };
+  return fetchJSON<{ insights: string[] }>("/api/stockbot/insights");
 }
 
 export async function getMarketHighlights() {
-  const { data } = await axios.get(buildUrl("/api/stockbot/highlights"), {
-    withCredentials: true,
-  });
-  return data as { highlights: string };
+  return fetchJSON<{ highlights: string }>("/api/stockbot/highlights");
 }
-

--- a/frontend/src/components/Stockbot/CompareRuns.tsx
+++ b/frontend/src/components/Stockbot/CompareRuns.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { fetchJSON } from "./lib/api";
+import { fetchJSON } from "@/api/http";
 import { RunSummary, Metrics, RunArtifacts } from "./lib/types";
 import { formatPct, formatSigned } from "./lib/formats";
 

--- a/frontend/src/components/Stockbot/Dashboard.tsx
+++ b/frontend/src/components/Stockbot/Dashboard.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
-import { fetchJSON } from "./lib/api";
+import { fetchJSON } from "@/api/http";
 import { RunSummary } from "./lib/types";
 import StatusChip from "./shared/StatusChip";
 import {

--- a/frontend/src/components/Stockbot/NewBacktest.tsx
+++ b/frontend/src/components/Stockbot/NewBacktest.tsx
@@ -6,7 +6,7 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { postJSON } from "./lib/api";
+import { postJSON } from "@/api/http";
 import { addRecentRun } from "./lib/runs";
 
 export default function NewBacktest({

--- a/frontend/src/components/Stockbot/NewTraining.tsx
+++ b/frontend/src/components/Stockbot/NewTraining.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { fetchJSON, postJSON } from "./lib/api";
+import { fetchJSON, postJSON } from "@/api/http";
 import { addRecentRun } from "./lib/runs";
 import type { JobStatusResponse, RunArtifacts } from "./lib/types";
 


### PR DESCRIPTION
## Summary
- add shared HTTP utility with buildUrl/fetchJSON/postJSON
- refactor Stockbot components and API modules to reuse the helper
- remove deprecated per-feature API helper

## Testing
- `npm test` (fails: vitest not found)
- `npm install` (fails: 403 Forbidden fetching packages)


------
https://chatgpt.com/codex/tasks/task_e_68ad2db009fc8331ba8abb866b1e761b