### PR TITLE
Improve error handling and disable API key check

### DIFF
--- a/backend/controllers/brokerController.js
+++ b/backend/controllers/brokerController.js
@@ -30,7 +30,15 @@ export async function getActiveBrokerPortfolio(req, res) {
 
     res.json(botRes.data);
   } catch (err) {
-    console.error('❌ Error fetching active broker portfolio:', err.message);
-    res.status(500).json({ error: 'Failed to fetch portfolio' });
+  console.error('❌ Error fetching active broker portfolio:', err);
+
+  if (axios.isAxiosError(err)) {
+    const status = err.response?.status || 500;
+    const body = err.response?.data || { error: err.message || 'Failed to fetch portfolio' };
+    console.error('❌ Python bot error response:', body);
+    return res.status(status).json(body);
+  }
+  return res.status(500).json({ error: err?.message || 'Failed to fetch portfolio' });
+
   }
 }

--- a/stockbot/api/routes/stockbot_routes.py
+++ b/stockbot/api/routes/stockbot_routes.py
@@ -16,7 +16,7 @@ from api.controllers.insights_controller import InsightsRequest, generate_insigh
 from api.controllers.highlights_controller import HighlightsRequest, generate_highlights
 
 
-def verify_api_key(request: Request):
+'''def verify_api_key(request: Request): -- security will be implemented soon
     expected = os.getenv("STOCKBOT_API_KEY")
     if not expected:
         raise RuntimeError("STOCKBOT_API_KEY not configured")
@@ -25,7 +25,9 @@ def verify_api_key(request: Request):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Unauthorized")
 
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(dependencies=[Depends(verify_api_key)])'''
+router = APIRouter()
+
 
 
 @router.post("/train")

--- a/stockbot/providers/alpaca_provider.py
+++ b/stockbot/providers/alpaca_provider.py
@@ -17,7 +17,7 @@ class AlpacaProvider(BaseProvider):
         app_key: str,
         app_secret: str,
         mode: str = "paper",  # "paper" or "live"
-        timeout: float = 5.0
+        timeout: float = 15.0
     ):
         # Pick base trading API based on mode
         if mode == "live":


### PR DESCRIPTION
Enhanced error handling in brokerController.js to return detailed error responses from the Python bot. Temporarily disabled API key verification in stockbot_routes.py for development purposes. Increased Alpaca provider timeout from 5s to 15s to reduce request failures.