### PR TITLE
Refactor Stockbot training sections for compact layout

### DIFF
--- a/frontend/src/components/Stockbot/NewTraining/CostsSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/CostsSection.tsx
@@ -28,22 +28,46 @@ export function CostsSection({
     <AccordionItem value="costs">
       <AccordionTrigger>Costs</AccordionTrigger>
       <AccordionContent>
-        <div className="grid md:grid-cols-4 gap-4 pt-2">
-          <div className="space-y-2">
-            <Label>Commission % Notional</Label>
-            <Input type="number" step="0.0001" value={commissionPct} onChange={(e) => setCommissionPct(safeNum(e.target.value, commissionPct))} />
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3 pt-2">
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Commission %</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={commissionPct}
+              onChange={(e) => setCommissionPct(safeNum(e.target.value, commissionPct))}
+              className="flex-1"
+            />
           </div>
-          <div className="space-y-2">
-            <Label>Commission per Share</Label>
-            <Input type="number" step="0.0001" value={commissionPerShare} onChange={(e) => setCommissionPerShare(safeNum(e.target.value, commissionPerShare))} />
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Per Share</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={commissionPerShare}
+              onChange={(e) => setCommissionPerShare(safeNum(e.target.value, commissionPerShare))}
+              className="flex-1"
+            />
           </div>
-          <div className="space-y-2">
-            <Label>Slippage (bps)</Label>
-            <Input type="number" step="0.1" value={slippageBps} onChange={(e) => setSlippageBps(safeNum(e.target.value, slippageBps))} />
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Slippage (bps)</Label>
+            <Input
+              type="number"
+              step="0.1"
+              value={slippageBps}
+              onChange={(e) => setSlippageBps(safeNum(e.target.value, slippageBps))}
+              className="flex-1"
+            />
           </div>
-          <div className="space-y-2">
-            <Label>Borrow Fee APR</Label>
-            <Input type="number" step="0.0001" value={borrowFeeApr} onChange={(e) => setBorrowFeeApr(safeNum(e.target.value, borrowFeeApr))} />
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Borrow Fee APR</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={borrowFeeApr}
+              onChange={(e) => setBorrowFeeApr(safeNum(e.target.value, borrowFeeApr))}
+              className="flex-1"
+            />
           </div>
         </div>
       </AccordionContent>

--- a/frontend/src/components/Stockbot/NewTraining/DataEnv.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/DataEnv.tsx
@@ -30,25 +30,45 @@ export function DataEnvironmentSection({
   return (
     <section className="rounded-xl border p-4">
       <div className="font-medium mb-4">Data & Environment</div>
-      <div className="grid md:grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label>Symbols (comma separated)</Label>
-          <Input value={symbols} onChange={(e) => setSymbols(e.target.value)} placeholder="AAPL,MSFT,…" />
+      <div className="grid md:grid-cols-2 gap-3">
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">Symbols</Label>
+          <Input
+            value={symbols}
+            onChange={(e) => setSymbols(e.target.value)}
+            placeholder="AAPL,MSFT,…"
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Interval</Label>
-          <Input value={interval} onChange={(e) => setInterval(e.target.value)} placeholder="1d" />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">Interval</Label>
+          <Input
+            value={interval}
+            onChange={(e) => setInterval(e.target.value)}
+            placeholder="1d"
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Start</Label>
-          <Input type="date" value={start} onChange={(e) => setStart(e.target.value)} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">Start</Label>
+          <Input
+            type="date"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>End</Label>
-          <Input type="date" value={end} onChange={(e) => setEnd(e.target.value)} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">End</Label>
+          <Input
+            type="date"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+            className="flex-1"
+          />
         </div>
-        <div className="col-span-full flex items-center justify-between rounded border p-3">
-          <Label className="mr-4">Adjusted Prices</Label>
+        <div className="col-span-full flex items-center gap-2 rounded border p-2">
+          <Label className="min-w-[160px]">Adjusted Prices</Label>
           <Switch checked={adjusted} onCheckedChange={setAdjusted} />
         </div>
       </div>

--- a/frontend/src/components/Stockbot/NewTraining/EpisodeSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/EpisodeSection.tsx
@@ -47,13 +47,18 @@ export function EpisodeSection({
   return (
     <section className="rounded-xl border p-4">
       <div className="font-medium mb-4">Episode</div>
-      <div className="grid md:grid-cols-4 gap-4">
-        <div className="space-y-2">
-          <Label>Lookback</Label>
-          <Input type="number" value={lookback} onChange={(e) => setLookback(safeNum(e.target.value, lookback))} />
+      <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3">
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">Lookback</Label>
+          <Input
+            type="number"
+            value={lookback}
+            onChange={(e) => setLookback(safeNum(e.target.value, lookback))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Horizon (bars)</Label>
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">Horizon (bars)</Label>
           <Input
             type="number"
             value={horizon ?? 0}
@@ -61,10 +66,11 @@ export function EpisodeSection({
               const val = safeNum(e.target.value, 0);
               setHorizon(val > 0 ? val : null);
             }}
+            className="flex-1"
           />
         </div>
-        <div className="space-y-2">
-          <Label>Episode Max Steps</Label>
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">Episode Max Steps</Label>
           <Input
             type="number"
             value={episodeMaxSteps ?? 0}
@@ -72,33 +78,61 @@ export function EpisodeSection({
               const val = safeNum(e.target.value, 0);
               setEpisodeMaxSteps(val > 0 ? val : null);
             }}
+            className="flex-1"
           />
         </div>
-        <div className="space-y-2">
-          <Label>Start Cash</Label>
-          <Input type="number" value={startCash} onChange={(e) => setStartCash(safeNum(e.target.value, startCash))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">Start Cash</Label>
+          <Input
+            type="number"
+            value={startCash}
+            onChange={(e) => setStartCash(safeNum(e.target.value, startCash))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Rebalance Epsilon (fraction of equity)</Label>
-          <Input type="number" step="0.0001" value={rebalanceEps} onChange={(e) => setRebalanceEps(safeNum(e.target.value, rebalanceEps))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">Rebalance Eps</Label>
+          <Input
+            type="number"
+            step="0.0001"
+            value={rebalanceEps}
+            onChange={(e) => setRebalanceEps(safeNum(e.target.value, rebalanceEps))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Mapping Mode</Label>
-          <select className="border rounded h-10 px-3 w-full" value={mappingMode} onChange={(e) => setMappingMode(e.target.value as any)}>
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">Mapping Mode</Label>
+          <select
+            className="flex-1 h-10 rounded border px-2"
+            value={mappingMode}
+            onChange={(e) => setMappingMode(e.target.value as any)}
+          >
             <option value="simplex_cash">simplex_cash (long-only + cash)</option>
             <option value="tanh_leverage">tanh_leverage (long/short)</option>
           </select>
         </div>
-        <div className="space-y-2">
-          <Label>invest_max</Label>
-          <Input type="number" step="0.01" value={investMax} onChange={(e) => setInvestMax(safeNum(e.target.value, investMax))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">invest_max</Label>
+          <Input
+            type="number"
+            step="0.01"
+            value={investMax}
+            onChange={(e) => setInvestMax(safeNum(e.target.value, investMax))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>max_step_change</Label>
-          <Input type="number" step="0.01" value={maxStepChange} onChange={(e) => setMaxStepChange(safeNum(e.target.value, maxStepChange))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[140px]">max_step_change</Label>
+          <Input
+            type="number"
+            step="0.01"
+            value={maxStepChange}
+            onChange={(e) => setMaxStepChange(safeNum(e.target.value, maxStepChange))}
+            className="flex-1"
+          />
         </div>
-        <div className="col-span-full flex items-center justify-between rounded border p-3">
-          <Label className="mr-4">Randomize Start</Label>
+        <div className="col-span-full flex items-center gap-2 rounded border p-2">
+          <Label className="min-w-[140px]">Randomize Start</Label>
           <Switch checked={randomizeStart} onCheckedChange={setRandomizeStart} />
         </div>
       </div>

--- a/frontend/src/components/Stockbot/NewTraining/ExecutionSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/ExecutionSection.tsx
@@ -28,11 +28,11 @@ export function ExecutionSection({
     <AccordionItem value="execution">
       <AccordionTrigger>Execution</AccordionTrigger>
       <AccordionContent>
-        <div className="grid md:grid-cols-4 gap-4 pt-2">
-          <div className="space-y-2">
-            <Label>Order Type</Label>
+        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3 pt-2">
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Order Type</Label>
             <select
-              className="border rounded h-10 px-3 w-full"
+              className="flex-1 h-10 rounded border px-2"
               value={orderType}
               onChange={(e) => setOrderType(e.target.value as "market" | "limit")}
             >
@@ -40,32 +40,35 @@ export function ExecutionSection({
               <option value="limit">limit</option>
             </select>
           </div>
-          <div className="space-y-2">
-            <Label>Limit Offset (bps)</Label>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Limit Offset (bps)</Label>
             <Input
               type="number"
               step="0.1"
               value={limitOffsetBps}
               onChange={(e) => setLimitOffsetBps(safeNum(e.target.value, limitOffsetBps))}
               disabled={orderType !== "limit"}
+              className="flex-1"
             />
           </div>
-          <div className="space-y-2">
-            <Label>Participation Cap (0–1)</Label>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Participation Cap</Label>
             <Input
               type="number"
               step="0.01"
               value={participationCap}
               onChange={(e) => setParticipationCap(safeNum(e.target.value, participationCap))}
+              className="flex-1"
             />
           </div>
-          <div className="space-y-2">
-            <Label>Impact k</Label>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[140px]">Impact k</Label>
             <Input
               type="number"
               step="0.001"
               value={impactK}
               onChange={(e) => setImpactK(safeNum(e.target.value, impactK))}
+              className="flex-1"
             />
           </div>
         </div>

--- a/frontend/src/components/Stockbot/NewTraining/FeaturesSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/FeaturesSection.tsx
@@ -23,18 +23,28 @@ export function FeaturesSection({
   return (
     <section className="rounded-xl border p-4">
       <div className="font-medium mb-4">Features</div>
-      <div className="grid md:grid-cols-3 gap-4">
-        <div className="col-span-full md:col-span-1 flex items-center justify-between rounded border p-3">
-          <Label className="mr-4">Use Custom Pipeline</Label>
+      <div className="grid md:grid-cols-2 gap-3">
+        <div className="col-span-full flex items-center gap-2 rounded border p-2">
+          <Label className="min-w-[160px]">Use Custom Pipeline</Label>
           <Switch checked={useCustomPipeline} onCheckedChange={setUseCustomPipeline} />
         </div>
-        <div className="space-y-2">
-          <Label>Feature Window</Label>
-          <Input type="number" value={featureWindow} onChange={(e) => setFeatureWindow(safeNum(e.target.value, featureWindow))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">Feature Window</Label>
+          <Input
+            type="number"
+            value={featureWindow}
+            onChange={(e) => setFeatureWindow(safeNum(e.target.value, featureWindow))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2 md:col-span-2">
-          <Label>Indicators (comma separated)</Label>
-          <Input value={indicators} onChange={(e) => setIndicators(e.target.value)} placeholder="logret,rsi14,vol20,macd,bb_upper,bb_lower" />
+        <div className="flex items-center gap-2 col-span-full">
+          <Label className="min-w-[160px]">Indicators</Label>
+          <Input
+            value={indicators}
+            onChange={(e) => setIndicators(e.target.value)}
+            placeholder="logret,rsi14,vol20,macd,bb_upper,bb_lower"
+            className="flex-1"
+          />
         </div>
       </div>
     </section>

--- a/frontend/src/components/Stockbot/NewTraining/PPOHyperparams.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/PPOHyperparams.tsx
@@ -52,17 +52,105 @@ export function PPOHyperparamsSection({
     <AccordionItem value="ppo">
       <AccordionTrigger>PPO Hyperparameters</AccordionTrigger>
       <AccordionContent>
-        <div className="grid md:grid-cols-3 gap-4 pt-2">
-          <div className="space-y-2"><Label>n_steps</Label><Input type="number" value={nSteps} onChange={(e)=>setNSteps(safeNum(e.target.value,nSteps))} /></div>
-          <div className="space-y-2"><Label>batch_size</Label><Input type="number" value={batchSize} onChange={(e)=>setBatchSize(safeNum(e.target.value,batchSize))} /></div>
-          <div className="space-y-2"><Label>learning_rate</Label><Input type="number" step="0.000001" value={learningRate} onChange={(e)=>setLearningRate(safeNum(e.target.value,learningRate))} /></div>
-          <div className="space-y-2"><Label>gamma</Label><Input type="number" step="0.0001" value={gamma} onChange={(e)=>setGamma(safeNum(e.target.value,gamma))} /></div>
-          <div className="space-y-2"><Label>gae_lambda</Label><Input type="number" step="0.0001" value={gaeLambda} onChange={(e)=>setGaeLambda(safeNum(e.target.value,gaeLambda))} /></div>
-          <div className="space-y-2"><Label>clip_range</Label><Input type="number" step="0.01" value={clipRange} onChange={(e)=>setClipRange(safeNum(e.target.value,clipRange))} /></div>
-          <div className="space-y-2"><Label>entropy_coef</Label><Input type="number" step="0.0001" value={entropyCoef} onChange={(e)=>setEntropyCoef(safeNum(e.target.value,entropyCoef))} /></div>
-          <div className="space-y-2"><Label>vf_coef</Label><Input type="number" step="0.01" value={vfCoef} onChange={(e)=>setVfCoef(safeNum(e.target.value,vfCoef))} /></div>
-          <div className="space-y-2"><Label>max_grad_norm</Label><Input type="number" step="0.01" value={maxGradNorm} onChange={(e)=>setMaxGradNorm(safeNum(e.target.value,maxGradNorm))} /></div>
-          <div className="space-y-2"><Label>dropout</Label><Input type="number" step="0.01" value={dropout} onChange={(e)=>setDropout(safeNum(e.target.value,dropout))} /></div>
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3 pt-2">
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">n_steps</Label>
+            <Input
+              type="number"
+              value={nSteps}
+              onChange={(e) => setNSteps(safeNum(e.target.value, nSteps))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">batch_size</Label>
+            <Input
+              type="number"
+              value={batchSize}
+              onChange={(e) => setBatchSize(safeNum(e.target.value, batchSize))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">learning_rate</Label>
+            <Input
+              type="number"
+              step="0.000001"
+              value={learningRate}
+              onChange={(e) => setLearningRate(safeNum(e.target.value, learningRate))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">gamma</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={gamma}
+              onChange={(e) => setGamma(safeNum(e.target.value, gamma))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">gae_lambda</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={gaeLambda}
+              onChange={(e) => setGaeLambda(safeNum(e.target.value, gaeLambda))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">clip_range</Label>
+            <Input
+              type="number"
+              step="0.01"
+              value={clipRange}
+              onChange={(e) => setClipRange(safeNum(e.target.value, clipRange))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">entropy_coef</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={entropyCoef}
+              onChange={(e) => setEntropyCoef(safeNum(e.target.value, entropyCoef))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">vf_coef</Label>
+            <Input
+              type="number"
+              step="0.01"
+              value={vfCoef}
+              onChange={(e) => setVfCoef(safeNum(e.target.value, vfCoef))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">max_grad_norm</Label>
+            <Input
+              type="number"
+              step="0.01"
+              value={maxGradNorm}
+              onChange={(e) => setMaxGradNorm(safeNum(e.target.value, maxGradNorm))}
+              className="flex-1"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Label className="min-w-[130px]">dropout</Label>
+            <Input
+              type="number"
+              step="0.01"
+              value={dropout}
+              onChange={(e) => setDropout(safeNum(e.target.value, dropout))}
+              className="flex-1"
+            />
+          </div>
         </div>
       </AccordionContent>
     </AccordionItem>

--- a/frontend/src/components/Stockbot/NewTraining/QuickSetup.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/QuickSetup.tsx
@@ -33,15 +33,17 @@ export function QuickSetupSection({
   return (
     <section className="rounded-xl border p-4">
       <div className="font-medium mb-4">Quick Setup</div>
-      <div className="grid md:grid-cols-3 gap-4">
-        <div className="col-span-full md:col-span-1 flex items-center justify-between rounded border p-3">
-          <Label className="mr-4">Normalize Observations</Label>
+      <div className="grid md:grid-cols-2 gap-3">
+        <div className="col-span-full flex items-center gap-2 rounded border p-2">
+          <Label className="min-w-[160px]">Normalize Observations</Label>
           <Switch checked={normalize} onCheckedChange={setNormalize} />
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="policy">Policy</Label>
+        <div className="flex items-center gap-2">
+          <Label htmlFor="policy" className="min-w-[160px]">
+            Policy
+          </Label>
           <select
-            className="border rounded h-10 px-3 w-full"
+            className="flex-1 h-10 rounded border px-2"
             id="policy"
             value={policy}
             onChange={(e) => setPolicy(e.target.value as any)}
@@ -51,33 +53,64 @@ export function QuickSetupSection({
             <option value="window_lstm">window_lstm</option>
           </select>
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="timesteps">Timesteps</Label>
+        <div className="flex items-center gap-2">
+          <Label htmlFor="timesteps" className="min-w-[160px]">
+            Timesteps
+          </Label>
           <Input
             type="number"
             id="timesteps"
             value={timesteps}
             onChange={(e) => setTimesteps(safeNum(e.target.value, timesteps))}
+            className="flex-1"
           />
-          <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-            <span>Examples:</span>
-            <button type="button" className="underline" onClick={() => setSymbols("AAPL,MSFT,GOOGL")}>AAPL,MSFT,GOOGL</button>
-            <button type="button" className="underline" onClick={() => setSymbols("XOM,CVX")}>XOM,CVX</button>
-            <button type="button" className="underline" onClick={() => setSymbols("SPY,QQQ")}>SPY,QQQ</button>
-          </div>
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="seed">Seed</Label>
+        <div className="flex items-center gap-2">
+          <Label htmlFor="seed" className="min-w-[160px]">
+            Seed
+          </Label>
           <Input
             type="number"
             id="seed"
             value={seed}
             onChange={(e) => setSeed(safeNum(e.target.value, seed))}
+            className="flex-1"
           />
         </div>
-        <div className="space-y-2">
-          <Label htmlFor="run-tag">Run Tag</Label>
-          <Input id="run-tag" value={outTag} onChange={(e) => setOutTag(e.target.value)} />
+        <div className="flex items-center gap-2 col-span-full md:col-span-1">
+          <Label htmlFor="run-tag" className="min-w-[160px]">
+            Run Tag
+          </Label>
+          <Input
+            id="run-tag"
+            value={outTag}
+            onChange={(e) => setOutTag(e.target.value)}
+            className="flex-1"
+          />
+        </div>
+        <div className="col-span-full flex flex-wrap gap-2 text-xs text-muted-foreground">
+          <span>Examples:</span>
+          <button
+            type="button"
+            className="underline"
+            onClick={() => setSymbols("AAPL,MSFT,GOOGL")}
+          >
+            AAPL,MSFT,GOOGL
+          </button>
+          <button
+            type="button"
+            className="underline"
+            onClick={() => setSymbols("XOM,CVX")}
+          >
+            XOM,CVX
+          </button>
+          <button
+            type="button"
+            className="underline"
+            onClick={() => setSymbols("SPY,QQQ")}
+          >
+            SPY,QQQ
+          </button>
         </div>
       </div>
     </section>

--- a/frontend/src/components/Stockbot/NewTraining/RewardSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/RewardSection.tsx
@@ -46,11 +46,11 @@ export function RewardSection({
   return (
     <section className="rounded-xl border p-4">
       <div className="font-medium mb-4">Reward & Shaping</div>
-      <div className="grid md:grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label>Reward Mode</Label>
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3">
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Reward Mode</Label>
           <select
-            className="border rounded h-10 px-3 w-full"
+            className="flex-1 h-10 rounded border px-2"
             value={rewardMode}
             onChange={(e) => setRewardMode(e.target.value as "delta_nav" | "log_nav")}
           >
@@ -58,32 +58,67 @@ export function RewardSection({
             <option value="log_nav">log_nav</option>
           </select>
         </div>
-        <div className="space-y-2">
-          <Label>Drawdown Penalty</Label>
-          <Input type="number" step="0.0001" value={wDrawdown} onChange={(e) => setWDrawdown(safeNum(e.target.value, wDrawdown))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Drawdown Penalty</Label>
+          <Input
+            type="number"
+            step="0.0001"
+            value={wDrawdown}
+            onChange={(e) => setWDrawdown(safeNum(e.target.value, wDrawdown))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Turnover Penalty</Label>
-          <Input type="number" step="0.0001" value={wTurnover} onChange={(e) => setWTurnover(safeNum(e.target.value, wTurnover))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Turnover Penalty</Label>
+          <Input
+            type="number"
+            step="0.0001"
+            value={wTurnover}
+            onChange={(e) => setWTurnover(safeNum(e.target.value, wTurnover))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Volatility Penalty</Label>
-          <Input type="number" step="0.0001" value={wVol} onChange={(e) => setWVol(safeNum(e.target.value, wVol))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Volatility Penalty</Label>
+          <Input
+            type="number"
+            step="0.0001"
+            value={wVol}
+            onChange={(e) => setWVol(safeNum(e.target.value, wVol))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Vol Window</Label>
-          <Input type="number" value={volWindow} onChange={(e) => setVolWindow(safeNum(e.target.value, volWindow))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Vol Window</Label>
+          <Input
+            type="number"
+            value={volWindow}
+            onChange={(e) => setVolWindow(safeNum(e.target.value, volWindow))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Leverage Penalty</Label>
-          <Input type="number" step="0.0001" value={wLeverage} onChange={(e) => setWLeverage(safeNum(e.target.value, wLeverage))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Leverage Penalty</Label>
+          <Input
+            type="number"
+            step="0.0001"
+            value={wLeverage}
+            onChange={(e) => setWLeverage(safeNum(e.target.value, wLeverage))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Stop Equity Fraction</Label>
-          <Input type="number" step="0.01" value={stopEqFrac} onChange={(e) => setStopEqFrac(safeNum(e.target.value, stopEqFrac))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Stop Eq Fraction</Label>
+          <Input
+            type="number"
+            step="0.01"
+            value={stopEqFrac}
+            onChange={(e) => setStopEqFrac(safeNum(e.target.value, stopEqFrac))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Sharpe Window (optional)</Label>
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Sharpe Window</Label>
           <Input
             type="number"
             value={sharpeWindow ?? 0}
@@ -91,10 +126,11 @@ export function RewardSection({
               const v = safeNum(e.target.value, 0);
               setSharpeWindow(v > 0 ? v : undefined);
             }}
+            className="flex-1"
           />
         </div>
-        <div className="space-y-2">
-          <Label>Sharpe Scale (optional)</Label>
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Sharpe Scale</Label>
           <Input
             type="number"
             step="0.0001"
@@ -103,6 +139,7 @@ export function RewardSection({
               const v = safeNum(e.target.value, 0);
               setSharpeScale(v > 0 ? v : undefined);
             }}
+            className="flex-1"
           />
         </div>
       </div>

--- a/frontend/src/components/Stockbot/NewTraining/RiskMargin.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/RiskMargin.tsx
@@ -31,25 +31,43 @@ export function RiskMarginSection({
   return (
     <section className="rounded-xl border p-4">
       <div className="font-medium mb-4">Risk / Margin</div>
-      <div className="grid md:grid-cols-4 gap-4">
-        <div className="space-y-2">
-          <Label>Max Gross Leverage</Label>
-          <Input type="number" step="0.1" value={maxGrossLev} onChange={(e) => setMaxGrossLev(safeNum(e.target.value, maxGrossLev))} />
+      <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3">
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Max Gross Lev</Label>
+          <Input
+            type="number"
+            step="0.1"
+            value={maxGrossLev}
+            onChange={(e) => setMaxGrossLev(safeNum(e.target.value, maxGrossLev))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Maintenance Margin</Label>
-          <Input type="number" step="0.01" value={maintenanceMargin} onChange={(e) => setMaintenanceMargin(safeNum(e.target.value, maintenanceMargin))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Maintenance Margin</Label>
+          <Input
+            type="number"
+            step="0.01"
+            value={maintenanceMargin}
+            onChange={(e) => setMaintenanceMargin(safeNum(e.target.value, maintenanceMargin))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Cash Borrow APR</Label>
-          <Input type="number" step="0.0001" value={cashBorrowApr} onChange={(e) => setCashBorrowApr(safeNum(e.target.value, cashBorrowApr))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[150px]">Cash Borrow APR</Label>
+          <Input
+            type="number"
+            step="0.0001"
+            value={cashBorrowApr}
+            onChange={(e) => setCashBorrowApr(safeNum(e.target.value, cashBorrowApr))}
+            className="flex-1"
+          />
         </div>
-        <div className="col-span-full md:col-span-1 flex items-center justify-between rounded border p-3">
-          <Label className="mr-4">Allow Short</Label>
+        <div className="col-span-full md:col-span-1 flex items-center gap-2 rounded border p-2">
+          <Label className="min-w-[150px]">Allow Short</Label>
           <Switch checked={allowShort} onCheckedChange={setAllowShort} />
         </div>
-        <div className="col-span-full md:col-span-1 flex items-center justify-between rounded border p-3">
-          <Label className="mr-4">Intraday Only</Label>
+        <div className="col-span-full md:col-span-1 flex items-center gap-2 rounded border p-2">
+          <Label className="min-w-[150px]">Intraday Only</Label>
           <Switch checked={intradayOnly} onCheckedChange={setIntradayOnly} />
         </div>
       </div>

--- a/frontend/src/components/Stockbot/NewTraining/TrainingSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/TrainingSection.tsx
@@ -31,30 +31,48 @@ export function TrainingSection({
   return (
     <section className="rounded-xl border p-4">
       <div className="font-medium mb-4">Training (advanced)</div>
-      <div className="grid md:grid-cols-3 gap-4">
-        <div className="col-span-full md:col-span-1 flex items-center justify-between rounded border p-3">
-          <Label className="mr-4">Normalize Observations</Label>
+      <div className="grid md:grid-cols-2 gap-3">
+        <div className="col-span-full flex items-center gap-2 rounded border p-2">
+          <Label className="min-w-[160px]">Normalize Observations</Label>
           <Switch checked={normalize} onCheckedChange={setNormalize} />
         </div>
-        <div className="space-y-2">
-          <Label>Policy</Label>
-          <select className="border rounded h-10 px-3 w-full" value={policy} onChange={(e) => setPolicy(e.target.value as any)}>
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">Policy</Label>
+          <select
+            className="flex-1 h-10 rounded border px-2"
+            value={policy}
+            onChange={(e) => setPolicy(e.target.value as any)}
+          >
             <option value="mlp">mlp</option>
             <option value="window_cnn">window_cnn</option>
             <option value="window_lstm">window_lstm</option>
           </select>
         </div>
-        <div className="space-y-2">
-          <Label>Timesteps</Label>
-          <Input type="number" value={timesteps} onChange={(e) => setTimesteps(safeNum(e.target.value, timesteps))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">Timesteps</Label>
+          <Input
+            type="number"
+            value={timesteps}
+            onChange={(e) => setTimesteps(safeNum(e.target.value, timesteps))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Seed</Label>
-          <Input type="number" value={seed} onChange={(e) => setSeed(safeNum(e.target.value, seed))} />
+        <div className="flex items-center gap-2">
+          <Label className="min-w-[160px]">Seed</Label>
+          <Input
+            type="number"
+            value={seed}
+            onChange={(e) => setSeed(safeNum(e.target.value, seed))}
+            className="flex-1"
+          />
         </div>
-        <div className="space-y-2">
-          <Label>Run Tag</Label>
-          <Input value={outTag} onChange={(e) => setOutTag(e.target.value)} />
+        <div className="flex items-center gap-2 col-span-full md:col-span-1">
+          <Label className="min-w-[160px]">Run Tag</Label>
+          <Input
+            value={outTag}
+            onChange={(e) => setOutTag(e.target.value)}
+            className="flex-1"
+          />
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- streamline new training wizard by arranging fields in flex-based grids
- condense sections like data environment, risk/margin, and rewards for better readability

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68b22a0d39f48331b1c34cf00cbe473d