### PR TITLE
feat: clarify stockbot options with tooltips

### DIFF
--- a/frontend/src/app/stockbot/page.tsx
+++ b/frontend/src/app/stockbot/page.tsx
@@ -11,6 +11,7 @@ import TrainingResults from "@/components/Stockbot/TrainingResults";
 import CompareRuns from "@/components/Stockbot/CompareRuns";
 import Settings from "@/components/Stockbot/Settings";
 import LiveTrading from "@/components/Stockbot/LiveTrading";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 export default function Page() {
   const [tab, setTab] = useState("dashboard");
@@ -19,7 +20,8 @@ export default function Page() {
 
   return (
     <div className="p-6 space-y-6">
-      <Tabs value={tab} onValueChange={setTab} className="space-y-6">
+      <TooltipProvider delayDuration={80}>
+        <Tabs value={tab} onValueChange={setTab} className="space-y-6">
         <TabsList className="w-full grid grid-cols-8 gap-2">
           <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
           <TabsTrigger value="new-training">New Training</TabsTrigger>
@@ -90,7 +92,8 @@ export default function Page() {
         <TabsContent value="settings">
           <Settings />
         </TabsContent>
-      </Tabs>
+        </Tabs>
+      </TooltipProvider>
     </div>
   );
 }

--- a/frontend/src/components/Stockbot/NewBacktest/DataRange.tsx
+++ b/frontend/src/components/Stockbot/NewBacktest/DataRange.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { TooltipLabel } from "../shared/TooltipLabel";
 
 interface DataRangeProps {
   symbols: string;
@@ -24,18 +24,21 @@ export function DataRangeSection({
       <div className="grid md:grid-cols-3 gap-4">
         <InputGroup
           label="Symbols"
+          tooltip="Comma-separated tickers"
           value={symbols}
           type="text"
           onChange={(v) => setSymbols(v)}
         />
         <InputGroup
           label="Start"
+          tooltip="Start date of historical data"
           value={start}
           type="date"
           onChange={(v) => setStart(v)}
         />
         <InputGroup
           label="End"
+          tooltip="End date of historical data"
           value={end}
           type="date"
           onChange={(v) => setEnd(v)}
@@ -47,15 +50,16 @@ export function DataRangeSection({
 
 interface InputGroupProps {
   label: string;
+  tooltip: string;
   value: string;
   type?: string;
   onChange: (v: string) => void;
 }
 
-function InputGroup({ label, value, onChange, type = "text" }: InputGroupProps) {
+function InputGroup({ label, tooltip, value, onChange, type = "text" }: InputGroupProps) {
   return (
     <div className="flex flex-col gap-1">
-      <Label className="text-sm font-medium">{label}</Label>
+      <TooltipLabel tooltip={tooltip}>{label}</TooltipLabel>
       <Input
         type={type}
         value={value}

--- a/frontend/src/components/Stockbot/NewBacktest/OutputOptions.tsx
+++ b/frontend/src/components/Stockbot/NewBacktest/OutputOptions.tsx
@@ -1,6 +1,6 @@
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { TooltipLabel } from "../shared/TooltipLabel";
 
 interface OutputOptionsProps {
   outTag: string;
@@ -21,11 +21,13 @@ export function OutputOptionsSection({
       <div className="grid md:grid-cols-3 gap-4">
         <InputGroup
           label="Run Tag"
+          tooltip="Optional label for this backtest run"
           value={outTag}
           onChange={setOutTag}
         />
         <SwitchGroup
           label="Normalize (eval)"
+          tooltip="Apply normalization when evaluating results"
           checked={normalize}
           onChange={setNormalize}
         />
@@ -36,14 +38,15 @@ export function OutputOptionsSection({
 
 interface InputGroupProps {
   label: string;
+  tooltip: string;
   value: string;
   onChange: (v: string) => void;
 }
 
-function InputGroup({ label, value, onChange }: InputGroupProps) {
+function InputGroup({ label, tooltip, value, onChange }: InputGroupProps) {
   return (
     <div className="flex flex-col gap-1">
-      <Label className="text-sm font-medium">{label}</Label>
+      <TooltipLabel tooltip={tooltip}>{label}</TooltipLabel>
       <Input
         type="text"
         value={value}
@@ -56,14 +59,15 @@ function InputGroup({ label, value, onChange }: InputGroupProps) {
 
 interface SwitchGroupProps {
   label: string;
+  tooltip: string;
   checked: boolean;
   onChange: (v: boolean) => void;
 }
 
-function SwitchGroup({ label, checked, onChange }: SwitchGroupProps) {
+function SwitchGroup({ label, tooltip, checked, onChange }: SwitchGroupProps) {
   return (
     <div className="flex flex-col gap-1">
-      <Label className="text-sm font-medium">{label}</Label>
+      <TooltipLabel tooltip={tooltip}>{label}</TooltipLabel>
       <div className="rounded border px-3 py-2 flex justify-between items-center">
         <span className="text-sm text-muted-foreground">Toggle</span>
         <Switch checked={checked} onCheckedChange={onChange} />

--- a/frontend/src/components/Stockbot/NewBacktest/PolicySource.tsx
+++ b/frontend/src/components/Stockbot/NewBacktest/PolicySource.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Button } from "@/components/ui/button";
+import { TooltipLabel } from "../shared/TooltipLabel";
 
 interface PolicySourceProps {
   mode: "trained" | "baseline" | "upload";
@@ -41,19 +41,32 @@ export function PolicySourceSection({
           if (!lockedMode) setMode(v as any);
         }}
       >
-        <RadioCard id="src-trained" value="trained" disabled={lockedMode} label="Trained run" />
+        <RadioCard
+          id="src-trained"
+          value="trained"
+          disabled={lockedMode}
+          label="Trained run"
+          tooltip="Use a previously trained policy"
+        />
         <RadioCard
           id="src-baseline"
           value="baseline"
           disabled={lockedMode && mode !== "baseline"}
           label="Baseline policy"
+          tooltip="Run with a simple baseline strategy"
         />
-        <RadioCard id="src-upload" value="upload" disabled={lockedMode} label="Upload PPO .zip" />
+        <RadioCard
+          id="src-upload"
+          value="upload"
+          disabled={lockedMode}
+          label="Upload PPO .zip"
+          tooltip="Upload a custom PPO model"
+        />
       </RadioGroup>
 
       {mode === "trained" && (
         <div className="space-y-2">
-          <Label>Run ID</Label>
+          <TooltipLabel tooltip="ID of the training run to evaluate">Run ID</TooltipLabel>
           <Input value={runId ?? ""} readOnly placeholder="Provided by Dashboard" />
           {!runId && (
             <div className="text-xs text-muted-foreground">
@@ -67,6 +80,7 @@ export function PolicySourceSection({
         <div className="w-fit max-w-md">
           <SelectGroup
             label="Baseline"
+            tooltip="Choose baseline strategy"
             value={baseline}
             onChange={(v) => setBaseline(v as any)}
             options={[
@@ -82,7 +96,7 @@ export function PolicySourceSection({
 
       {mode === "upload" && (
         <div className="space-y-2">
-          <Label>Policy .zip</Label>
+          <TooltipLabel tooltip="Upload a PPO policy archive">Policy .zip</TooltipLabel>
           <div className="flex items-center gap-3">
             <Input
               type="file"
@@ -114,30 +128,36 @@ interface RadioCardProps {
   id: string;
   value: string;
   label: string;
+  tooltip: string;
   disabled?: boolean;
 }
 
-function RadioCard({ id, value, label, disabled }: RadioCardProps) {
+function RadioCard({ id, value, label, tooltip, disabled }: RadioCardProps) {
   return (
     <div className="flex items-center gap-2 rounded border p-3">
       <RadioGroupItem id={id} value={value} disabled={disabled} />
-      <Label htmlFor={id}>{label}</Label>
+      <TooltipLabel htmlFor={id} tooltip={tooltip}>
+        {label}
+      </TooltipLabel>
     </div>
   );
 }
 
 interface SelectGroupProps {
   label: string;
+  tooltip: string;
   value: string;
   onChange: (v: string) => void;
   options: { value: string; label: string }[];
   className?: string;
 }
 
-function SelectGroup({ label, value, onChange, options, className }: SelectGroupProps) {
+function SelectGroup({ label, tooltip, value, onChange, options, className }: SelectGroupProps) {
   return (
     <div className={`flex flex-col gap-1 ${className ?? ""}`}>
-      <Label className="text-sm font-medium">{label}</Label>
+      <TooltipLabel className="text-sm font-medium" tooltip={tooltip}>
+        {label}
+      </TooltipLabel>
       <select
         className="border rounded h-10 px-3 bg-background text-foreground"
         value={value}

--- a/frontend/src/components/Stockbot/NewTraining/DataEnv.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/DataEnv.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { TooltipLabel } from "../shared/TooltipLabel";
 
 interface DataEnvProps {
   symbols: string;
@@ -35,24 +35,28 @@ export function DataEnvironmentSection({
       <div className="grid md:grid-cols-2 gap-4">
         <InputGroup
           label="Symbols"
+          tooltip="Comma-separated stock tickers"
           value={symbols}
           onChange={setSymbols}
           placeholder="AAPL,MSFT,…"
         />
         <InputGroup
           label="Interval"
+          tooltip="Data frequency such as 1d or 1h"
           value={interval}
           onChange={setInterval}
           placeholder="1d"
         />
         <InputGroup
           label="Start"
+          tooltip="Start date for training data"
           value={start}
           onChange={setStart}
           type="date"
         />
         <InputGroup
           label="End"
+          tooltip="End date for training data"
           value={end}
           onChange={setEnd}
           type="date"
@@ -60,6 +64,7 @@ export function DataEnvironmentSection({
         <div className="md:col-span-1">
           <SwitchGroup
             label="Adjusted Prices"
+            tooltip="Use prices adjusted for splits and dividends"
             checked={adjusted}
             onChange={setAdjusted}
           />
@@ -71,6 +76,7 @@ export function DataEnvironmentSection({
 
 interface InputGroupProps {
   label: string;
+  tooltip: string;
   value: string;
   onChange: (v: string) => void;
   placeholder?: string;
@@ -79,6 +85,7 @@ interface InputGroupProps {
 
 function InputGroup({
   label,
+  tooltip,
   value,
   onChange,
   placeholder,
@@ -86,7 +93,7 @@ function InputGroup({
 }: InputGroupProps) {
   return (
     <div className="flex flex-col gap-1">
-      <Label className="text-sm font-medium">{label}</Label>
+      <TooltipLabel tooltip={tooltip}>{label}</TooltipLabel>
       <Input
         type={type}
         value={value}
@@ -100,14 +107,15 @@ function InputGroup({
 
 interface SwitchGroupProps {
   label: string;
+  tooltip: string;
   checked: boolean;
   onChange: (v: boolean) => void;
 }
 
-function SwitchGroup({ label, checked, onChange }: SwitchGroupProps) {
+function SwitchGroup({ label, tooltip, checked, onChange }: SwitchGroupProps) {
   return (
     <div className="flex flex-col gap-1 w-fit">
-      <Label className="text-sm font-medium">{label}</Label>
+      <TooltipLabel tooltip={tooltip}>{label}</TooltipLabel>
       <div className="border rounded px-3 py-2 flex items-center justify-between gap-4 min-w-[180px]">
         <span className="text-sm text-muted-foreground">Toggle</span>
         <Switch checked={checked} onCheckedChange={onChange} />

--- a/frontend/src/components/Stockbot/NewTraining/ExecutionSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/ExecutionSection.tsx
@@ -1,7 +1,7 @@
 import { AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { safeNum } from "./utils";
+import { TooltipLabel } from "../shared/TooltipLabel";
 
 interface ExecutionProps {
   orderType: "market" | "limit";
@@ -30,7 +30,9 @@ export function ExecutionSection({
       <AccordionContent>
         <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-3 pt-2">
           <div className="flex items-center gap-2">
-            <Label className="min-w-[140px]">Order Type</Label>
+            <TooltipLabel className="min-w-[140px]" tooltip="Type of order to simulate">
+              Order Type
+            </TooltipLabel>
             <select
               className="flex-1 h-10 rounded border px-2"
               value={orderType}
@@ -41,7 +43,9 @@ export function ExecutionSection({
             </select>
           </div>
           <div className="flex items-center gap-2">
-            <Label className="min-w-[140px]">Limit Offset (bps)</Label>
+            <TooltipLabel className="min-w-[140px]" tooltip="Basis point offset for limit orders">
+              Limit Offset (bps)
+            </TooltipLabel>
             <Input
               type="number"
               step="0.1"
@@ -52,7 +56,9 @@ export function ExecutionSection({
             />
           </div>
           <div className="flex items-center gap-2">
-            <Label className="min-w-[140px]">Participation Cap</Label>
+            <TooltipLabel className="min-w-[140px]" tooltip="Maximum trade size as share of volume">
+              Participation Cap
+            </TooltipLabel>
             <Input
               type="number"
               step="0.01"
@@ -62,7 +68,9 @@ export function ExecutionSection({
             />
           </div>
           <div className="flex items-center gap-2">
-            <Label className="min-w-[140px]">Impact k</Label>
+            <TooltipLabel className="min-w-[140px]" tooltip="Price impact coefficient">
+              Impact k
+            </TooltipLabel>
             <Input
               type="number"
               step="0.001"

--- a/frontend/src/components/Stockbot/NewTraining/FeaturesSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/FeaturesSection.tsx
@@ -1,7 +1,7 @@
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { safeNum } from "./utils";
+import { TooltipLabel } from "../shared/TooltipLabel";
 
 interface FeaturesProps {
   useCustomPipeline: boolean;
@@ -25,11 +25,15 @@ export function FeaturesSection({
       <div className="font-medium mb-4">Features</div>
       <div className="grid md:grid-cols-2 gap-3">
         <div className="col-span-full flex items-center gap-2 rounded border p-2">
-          <Label className="min-w-[160px]">Use Custom Pipeline</Label>
+          <TooltipLabel className="min-w-[160px]" tooltip="Enable custom feature pipeline">
+            Use Custom Pipeline
+          </TooltipLabel>
           <Switch checked={useCustomPipeline} onCheckedChange={setUseCustomPipeline} />
         </div>
         <div className="flex items-center gap-2">
-          <Label className="min-w-[160px]">Feature Window</Label>
+          <TooltipLabel className="min-w-[160px]" tooltip="Number of periods used for each feature">
+            Feature Window
+          </TooltipLabel>
           <Input
             type="number"
             value={featureWindow}
@@ -38,7 +42,9 @@ export function FeaturesSection({
           />
         </div>
         <div className="flex items-center gap-2 col-span-full">
-          <Label className="min-w-[160px]">Indicators</Label>
+          <TooltipLabel className="min-w-[160px]" tooltip="Comma-separated technical indicators">
+            Indicators
+          </TooltipLabel>
           <Input
             value={indicators}
             onChange={(e) => setIndicators(e.target.value)}

--- a/frontend/src/components/Stockbot/RunDetail.tsx
+++ b/frontend/src/components/Stockbot/RunDetail.tsx
@@ -7,6 +7,7 @@ import {
   Table, TableHeader, TableRow, TableHead, TableBody, TableCell,
 } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { parseCSVText, drawdownFromEquity } from "./lib/csv";
 import { formatPct, formatUSD, formatSigned } from "./lib/formats";
 import { Metrics } from "./lib/types";
@@ -302,7 +303,12 @@ export default function RunDetail() {
         <div className="flex flex-wrap items-center gap-3">
           <div className="text-lg font-semibold">Run Detail</div>
           <div className="flex-1" />
-          <Button variant="outline" size="sm" onClick={resetAll}>Reset</Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="outline" size="sm" onClick={resetAll}>Reset</Button>
+            </TooltipTrigger>
+            <TooltipContent>Clear all loaded run data</TooltipContent>
+          </Tooltip>
           <label>
             <input type="file" multiple accept=".csv,application/json" onChange={onFileInput} className="hidden" id="upload-artifacts"/>
             <Button asChild size="sm">

--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -5,8 +5,8 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { TooltipLabel } from "./shared/TooltipLabel";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import api from "@/api/client";
 import type { RunSummary } from "./lib/types";
@@ -272,7 +272,9 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
           <div className="text-lg font-semibold">Training Results</div>
           <div className="flex-1" />
           <div className="hidden md:block w-64">
-            <Label className="text-xs">Run</Label>
+            <TooltipLabel className="text-xs" tooltip="Select a training run to inspect">
+              Run
+            </TooltipLabel>
             <select
               className="border rounded h-10 px-3 w-full"
               value={runId}
@@ -284,6 +286,7 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
             </select>
           </div>
           <div className="flex items-center gap-2">
+            <TooltipLabel tooltip="ID of a specific run">Run ID</TooltipLabel>
             <Input
               value={runId}
               onChange={(e) => setRunId(e.target.value)}
@@ -293,7 +296,9 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
             <Button size="sm" onClick={onLoad} disabled={!runId || loading}>{loading ? "Loading…" : "Load"}</Button>
           </div>
           <div className="flex items-center gap-2 rounded border px-2 py-1">
-            <Label className="text-sm">Auto‑refresh</Label>
+            <TooltipLabel className="text-sm" tooltip="Automatically reload metrics">
+              Auto‑refresh
+            </TooltipLabel>
             <Switch checked={autoRefresh} onCheckedChange={setAutoRefresh} />
           </div>
         </div>
@@ -503,7 +508,9 @@ function ActionsHistogramSection({ runId, tags }: { runId: string; tags: TBTags 
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-2">
-        <Label className="text-xs">Tag</Label>
+        <TooltipLabel className="text-xs" tooltip="TensorBoard tag to visualize">
+          Tag
+        </TooltipLabel>
         <select className="border rounded h-9 px-2" value={tag || ""} onChange={(e)=>setTag(e.target.value)}>
           {(tags?.histograms || []).map((t) => (
             <option key={t} value={t}>{t}</option>

--- a/frontend/src/components/Stockbot/shared/TooltipLabel.tsx
+++ b/frontend/src/components/Stockbot/shared/TooltipLabel.tsx
@@ -1,0 +1,25 @@
+import { Label, LabelProps } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
+
+interface TooltipLabelProps extends LabelProps {
+  tooltip: ReactNode;
+}
+
+export function TooltipLabel({ className, children, tooltip, ...props }: TooltipLabelProps) {
+  return (
+    <div className="flex items-center gap-1">
+      <Label className={cn("text-sm font-medium", className)} {...props}>
+        {children}
+      </Label>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+        </TooltipTrigger>
+        <TooltipContent>{tooltip}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `TooltipLabel` component for consistent tooltips
- document data, execution, feature and backtest options with descriptions
- annotate run detail controls and training results filters with tooltips

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm test` *(fails: sh: 1: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b234c51e1083318f82d69e9edf42e6