### PR TITLE
feat: add probabilistic regime engine

### DIFF
--- a/stockbot/api/controllers/prob_controller.py
+++ b/stockbot/api/controllers/prob_controller.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from pydantic import BaseModel
+from typing import List
+
+from prob import train_model, infer_sequence
+
+
+class ProbTrainRequest(BaseModel):
+    series: List[float]
+    n_states: int = 2
+    out_dir: str
+
+
+class ProbInferRequest(BaseModel):
+    series: List[float]
+    model_dir: str
+
+
+def train(req: ProbTrainRequest) -> dict:
+    out = Path(req.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    train_model(req.series, req.n_states, str(out))
+    return {"out_dir": str(out)}
+
+
+def infer(req: ProbInferRequest) -> dict:
+    return infer_sequence(req.model_dir, req.series)

--- a/stockbot/api/routes/prob_routes.py
+++ b/stockbot/api/routes/prob_routes.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter
+
+from api.controllers.prob_controller import (
+    ProbTrainRequest,
+    ProbInferRequest,
+    train,
+    infer,
+)
+
+router = APIRouter()
+
+
+@router.post("/train")
+async def train_endpoint(req: ProbTrainRequest):
+    return train(req)
+
+
+@router.post("/infer")
+async def infer_endpoint(req: ProbInferRequest):
+    return infer(req)

--- a/stockbot/prob/__init__.py
+++ b/stockbot/prob/__init__.py
@@ -1,0 +1,16 @@
+"""Probability models for StockBot.
+
+Provides regime-switching probabilistic engines used to estimate
+state/posterior probabilities and next-step edge.  This module is kept
+intentionally light-weight so it can be imported by the API layer and
+CLI utilities.
+"""
+
+from .model import RegimeHMM, train_model, load_model, infer_sequence
+
+__all__ = [
+    "RegimeHMM",
+    "train_model",
+    "load_model",
+    "infer_sequence",
+]

--- a/stockbot/prob/infer.py
+++ b/stockbot/prob/infer.py
@@ -1,0 +1,34 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from .model import infer_sequence
+
+
+def _load_series(path: str) -> List[float]:
+    p = Path(path)
+    if p.suffix.lower() == ".json":
+        return json.loads(p.read_text())
+    elif p.suffix.lower() in {".txt", ".csv"}:
+        return [float(x) for x in p.read_text().replace(",", " ").split() if x]
+    else:
+        raise ValueError("Unsupported file format")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Infer regime probabilities")
+    parser.add_argument("model_dir", help="Directory with saved model")
+    parser.add_argument("data", help="Path to return series (json/csv)")
+    parser.add_argument("--out", help="Optional path to save inference results")
+    args = parser.parse_args()
+    series = _load_series(args.data)
+    result = infer_sequence(args.model_dir, series)
+    if args.out:
+        Path(args.out).write_text(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/stockbot/prob/model.py
+++ b/stockbot/prob/model.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import os
+import pickle
+from dataclasses import dataclass
+from math import erf, sqrt, exp, pi
+from typing import List, Dict, Any
+
+import numpy as np
+from sklearn.cluster import KMeans
+
+
+def _gaussian_pdf(x: float, mean: float, std: float) -> float:
+    std = max(std, 1e-6)
+    return (1.0 / (std * sqrt(2 * pi))) * exp(-0.5 * ((x - mean) / std) ** 2)
+
+
+def _gaussian_cdf_pos(mean: float, std: float) -> float:
+    std = max(std, 1e-6)
+    return 0.5 * (1 + erf(mean / (std * sqrt(2))))
+
+
+@dataclass
+class RegimeHMM:
+    """Simple Gaussian HMM estimated via clustering and counting."""
+
+    n_states: int
+    transition: np.ndarray | None = None
+    emissions: List[tuple] | None = None  # (mean, std)
+    state_names: List[str] | None = None
+
+    def fit(self, series: List[float]) -> "RegimeHMM":
+        X = np.array(series).reshape(-1, 1)
+        kmeans = KMeans(n_clusters=self.n_states, n_init=10, random_state=0).fit(X)
+        labels = kmeans.labels_
+        self.state_names = [f"state_{i}" for i in range(self.n_states)]
+        trans = np.zeros((self.n_states, self.n_states))
+        for i in range(len(labels) - 1):
+            trans[labels[i], labels[i + 1]] += 1
+        trans = np.where(trans.sum(axis=1, keepdims=True) == 0,
+                         1.0 / self.n_states,
+                         trans)
+        trans = trans / trans.sum(axis=1, keepdims=True)
+        self.transition = trans
+        self.emissions = []
+        for i in range(self.n_states):
+            vals = X[labels == i].flatten()
+            if len(vals) == 0:
+                mean, std = 0.0, 1.0
+            else:
+                mean, std = float(vals.mean()), float(vals.std() or 1e-6)
+            self.emissions.append((mean, std))
+        return self
+
+    # ---- Serialization ---------------------------------------------------------
+    def save(self, out_dir: str) -> None:
+        if self.transition is None or self.emissions is None:
+            raise ValueError("Model not trained")
+        os.makedirs(out_dir, exist_ok=True)
+        np.save(os.path.join(out_dir, "transition.npy"), self.transition)
+        with open(os.path.join(out_dir, "emissions.pkl"), "wb") as f:
+            pickle.dump(self.emissions, f)
+        meta = {"state_names": self.state_names}
+        with open(os.path.join(out_dir, "state_meta.json"), "w") as f:
+            json.dump(meta, f)
+
+    @classmethod
+    def load(cls, model_dir: str) -> "RegimeHMM":
+        trans = np.load(os.path.join(model_dir, "transition.npy"))
+        with open(os.path.join(model_dir, "emissions.pkl"), "rb") as f:
+            emissions = pickle.load(f)
+        with open(os.path.join(model_dir, "state_meta.json")) as f:
+            meta = json.load(f)
+        return cls(
+            n_states=len(emissions),
+            transition=trans,
+            emissions=emissions,
+            state_names=meta.get("state_names"),
+        )
+
+    # ---- Inference -------------------------------------------------------------
+    def infer(self, series: List[float]) -> Dict[str, Any]:
+        if self.transition is None or self.emissions is None:
+            raise ValueError("Model not loaded")
+        n = len(series)
+        m = self.n_states
+        start = np.full(m, 1.0 / m)
+        alpha = np.zeros((n, m))
+        for j in range(m):
+            mean, std = self.emissions[j]
+            alpha[0, j] = start[j] * _gaussian_pdf(series[0], mean, std)
+        alpha[0] /= alpha[0].sum()
+        for t in range(1, n):
+            for j in range(m):
+                mean, std = self.emissions[j]
+                emit = _gaussian_pdf(series[t], mean, std)
+                alpha[t, j] = emit * np.dot(alpha[t - 1], self.transition[:, j])
+            alpha[t] /= alpha[t].sum()
+        posteriors = [dict(zip(self.state_names, alpha[t])) for t in range(n)]
+        next_state = np.dot(alpha[-1], self.transition)
+        p_up_state = [_gaussian_cdf_pos(*e) for e in self.emissions]
+        p_up = float(np.dot(next_state, p_up_state))
+        return {"posteriors": posteriors, "p_up": p_up}
+
+
+# Convenience functions ---------------------------------------------------------
+
+def train_model(series: List[float], n_states: int, out_dir: str) -> str:
+    model = RegimeHMM(n_states=n_states).fit(series)
+    model.save(out_dir)
+    return out_dir
+
+
+def load_model(model_dir: str) -> RegimeHMM:
+    return RegimeHMM.load(model_dir)
+
+
+def infer_sequence(model_dir: str, series: List[float]) -> Dict[str, Any]:
+    model = load_model(model_dir)
+    return model.infer(series)

--- a/stockbot/prob/train.py
+++ b/stockbot/prob/train.py
@@ -1,0 +1,30 @@
+import argparse
+import json
+from pathlib import Path
+from typing import List
+
+from .model import train_model
+
+
+def _load_series(path: str) -> List[float]:
+    p = Path(path)
+    if p.suffix.lower() == ".json":
+        return json.loads(p.read_text())
+    elif p.suffix.lower() in {".txt", ".csv"}:
+        return [float(x) for x in p.read_text().replace(",", " ").split() if x]
+    else:
+        raise ValueError("Unsupported file format")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train regime HMM")
+    parser.add_argument("data", help="Path to return series (json/csv)")
+    parser.add_argument("out", help="Output directory for artifacts")
+    parser.add_argument("--states", type=int, default=2, help="Number of regimes")
+    args = parser.parse_args()
+    series = _load_series(args.data)
+    train_model(series, args.states, args.out)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/stockbot/server.py
+++ b/stockbot/server.py
@@ -4,6 +4,7 @@ import os
 from fastapi.staticfiles import StaticFiles
 from api.routes.broker_routes import router as broker_router
 from api.routes.stockbot_routes import router as stockbot_router
+from api.routes.prob_routes import router as prob_router
 from api.controllers.stockbot_controller import RUNS_DIR
 from pathlib import Path
 
@@ -33,6 +34,7 @@ if os.getenv("INCLUDE_JARVIS", "true").lower() not in ("0", "false"):
 
 app.include_router(broker_router,  prefix="/api/stockbot/broker")
 app.include_router(stockbot_router, prefix="/api/stockbot")
+app.include_router(prob_router,    prefix="/api/stockbot/prob")
 
 
 app.mount("/runs", StaticFiles(directory=str(RUNS_DIR), html=False), name="runs")

--- a/stockbot/tests/test_prob.py
+++ b/stockbot/tests/test_prob.py
@@ -1,0 +1,29 @@
+import os
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+os.environ["INCLUDE_JARVIS"] = "0"
+from server import app  # noqa: E402
+
+
+def test_train_and_infer(tmp_path):
+    client = TestClient(app)
+    series = [0.1, -0.2, 0.05, 0.03, -0.1, 0.2]
+    out_dir = tmp_path / "model"
+    res = client.post(
+        "/api/stockbot/prob/train",
+        json={"series": series, "n_states": 2, "out_dir": str(out_dir)},
+    )
+    assert res.status_code == 200
+    assert out_dir.joinpath("transition.npy").exists()
+    res2 = client.post(
+        "/api/stockbot/prob/infer",
+        json={"series": series, "model_dir": str(out_dir)},
+    )
+    assert res2.status_code == 200
+    data = res2.json()
+    assert "posteriors" in data and "p_up" in data
+    assert len(data["posteriors"]) == len(series)


### PR DESCRIPTION
## Summary
- add new `prob` package implementing simple Gaussian HMM with clustering-based training and forward inference
- expose `/api/stockbot/prob/train` and `/api/stockbot/prob/infer` routes with FastAPI controllers
- wire new probability service into server and add CLI helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3bf2e6c488331ab2227b5c20892b1