### PR TITLE
Implement turnover tracking and expanded performance metrics

### DIFF
--- a/stockbot/rl/metrics.py
+++ b/stockbot/rl/metrics.py
@@ -1,21 +1,67 @@
 from __future__ import annotations
 import numpy as np
 
+TRADING_DAYS = 252
+
+def _returns(equity_curve: np.ndarray, start_cash: float) -> np.ndarray:
+    """Simple return series from equity curve (assumes 1 step = 1 bar)."""
+    eq = np.asarray(equity_curve, dtype=np.float64)
+    if eq.size == 0:
+        return np.empty(0, dtype=np.float64)
+    eq0 = float(start_cash)
+    full = np.concatenate([[eq0], eq])
+    rets = np.diff(full) / max(eq0, 1e-9)
+    return rets
+
 def total_return(equity_curve: np.ndarray, start_cash: float) -> float:
-    if equity_curve.size == 0: return 0.0
+    if equity_curve.size == 0:
+        return 0.0
     return (float(equity_curve[-1]) - float(start_cash)) / float(start_cash)
 
 def max_drawdown(equity_curve: np.ndarray) -> float:
-    if equity_curve.size == 0: return 0.0
+    if equity_curve.size == 0:
+        return 0.0
     peaks = np.maximum.accumulate(equity_curve)
     dd = 1.0 - (equity_curve / np.maximum(peaks, 1e-9))
     return float(np.max(dd))
 
+def sharpe(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    r = _returns(equity_curve, start_cash)
+    if r.size < 2:
+        return 0.0
+    sd = r.std(ddof=0)
+    if sd < 1e-12:
+        return 0.0
+    return float(r.mean() / sd * np.sqrt(freq))
+
+def sortino(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    r = _returns(equity_curve, start_cash)
+    if r.size < 2:
+        return 0.0
+    downside = r[r < 0.0]
+    dd = downside.std(ddof=0)
+    if dd < 1e-12:
+        return 0.0
+    return float(r.mean() / dd * np.sqrt(freq))
+
+def cagr(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    if equity_curve.size == 0:
+        return 0.0
+    years = equity_curve.size / max(freq, 1)
+    gross = max(float(equity_curve[-1]) / max(start_cash, 1e-12), 1e-12)
+    return float(gross ** (1.0 / max(years, 1e-9)) - 1.0)
+
+def calmar(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    mdd = max_drawdown(equity_curve)
+    if mdd < 1e-12:
+        return 0.0
+    return float(cagr(equity_curve, start_cash, freq) / mdd)
+
+def turnover(turnover_steps: np.ndarray) -> float:
+    if turnover_steps.size == 0:
+        return 0.0
+    return float(np.sum(np.abs(turnover_steps)))
+
 def daily_sharpe(equity_curve: np.ndarray, start_cash: float) -> float:
-    """
-    Approximates 'daily' Sharpe by treating each step as one bar (e.g., 1d).
-    """
-    if equity_curve.size < 2: return 0.0
-    rets = np.diff(equity_curve) / max(start_cash, 1e-9)
-    if rets.std() < 1e-12: return 0.0
-    return float(rets.mean() / rets.std())
+    """Legacy alias of sharpe() using 1 step = 1 day."""
+    return sharpe(equity_curve, start_cash, freq=1)

--- a/stockbot/rl/smoke_test.py
+++ b/stockbot/rl/smoke_test.py
@@ -13,7 +13,7 @@ from stable_baselines3 import PPO
 
 from stockbot.env.config import EnvConfig
 from stockbot.rl.utils import make_env, Split, episode_rollout
-from stockbot.rl.metrics import total_return, max_drawdown, daily_sharpe
+from stockbot.rl.metrics import total_return, max_drawdown, sharpe, sortino, calmar, turnover
 
 def main():
     ap = argparse.ArgumentParser()
@@ -34,11 +34,14 @@ def main():
 
     from stockbot.env.config import EpisodeConfig
     start_cash = cfg.episode.start_cash if isinstance(cfg.episode, EpisodeConfig) else 100_000.0
-    curve = episode_rollout(eval_env, model, deterministic=True, seed=42)
+    curve, to = episode_rollout(eval_env, model, deterministic=True, seed=42)
     print("\n== Smoke Test Metrics (eval split) ==")
     print(f"TotalReturn: {total_return(curve, start_cash):+.3f}")
     print(f"MaxDrawdown: {max_drawdown(curve):.3f}")
-    print(f"Sharpe(d):   {daily_sharpe(curve, start_cash):.3f}")
+    print(f"Sharpe:      {sharpe(curve, start_cash):.3f}")
+    print(f"Sortino:     {sortino(curve, start_cash):.3f}")
+    print(f"Calmar:      {calmar(curve, start_cash):.3f}")
+    print(f"Turnover:    {turnover(to):.3f}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Track per-episode turnover in `PortfolioTradingEnv` and surface cumulative turnover in step info
- Extend RL metrics with Sharpe, Sortino, Calmar and turnover calculations; episode_rollout now returns turnover data
- Update training, evaluation and smoke-test scripts to report new net-of-cost metrics

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'stockbot')*
- `python -m py_compile stockbot/env/portfolio_env.py stockbot/rl/metrics.py stockbot/rl/utils.py stockbot/rl/train_ppo.py stockbot/rl/eval_agent.py stockbot/rl/smoke_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3c0e7bc288331b6d6bab931d881cd