### PR TITLE
Surface net performance KPIs and seed aggregates

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -9,7 +9,9 @@ import { Switch } from "@/components/ui/switch";
 import { TooltipLabel } from "./shared/TooltipLabel";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import api from "@/api/client";
-import type { RunSummary } from "./lib/types";
+import type { RunSummary, Metrics, RunArtifacts } from "./lib/types";
+import { parseCSV, drawdownFromEquity } from "./lib/csv";
+import { formatPct, formatSigned } from "./lib/formats";
 import {
   ResponsiveContainer,
   LineChart,
@@ -20,6 +22,9 @@ import {
   Tooltip,
   BarChart,
   Bar,
+  AreaChart,
+  Area,
+  ErrorBar,
 } from "recharts";
 
 type TBTags = { scalars: string[]; histograms: string[] };
@@ -31,6 +36,16 @@ const pickFirst = (candidates: string[], available: string[]): string | null => 
   return null;
 };
 
+const statTriple = (arr: number[]) => {
+  if (!arr.length) return { median: 0, q1: 0, q3: 0 };
+  const s = [...arr].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  const median = s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+  const q1 = s[Math.floor((s.length - 1) / 4)];
+  const q3 = s[Math.floor((s.length - 1) * 3 / 4)];
+  return { median, q1, q3 };
+};
+
 export default function TrainingResults({ initialRunId }: { initialRunId?: string }) {
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [runId, setRunId] = useState<string>(initialRunId || "");
@@ -39,6 +54,9 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   const [tags, setTags] = useState<TBTags | null>(null);
   const [series, setSeries] = useState<Record<string, TBPoint[]>>({});
   const [gradMatrix, setGradMatrix] = useState<GradMatrix | null>(null);
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+  const [equity, setEquity] = useState<Array<{ step: number; equity: number }>>([]);
+  const [drawdown, setDrawdown] = useState<Array<{ step: number; dd: number }>>([]);
   const tickRef = useRef(0);
   const busyRef = useRef(false);
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
@@ -48,6 +66,12 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   const [showTiming, setShowTiming] = useState(false);
   const [showGrads, setShowGrads] = useState(true);
   const [showDists, setShowDists] = useState(false);
+  const [showSeed, setShowSeed] = useState(false);
+  const [seedAgg, setSeedAgg] = useState<{
+    metrics?: Record<string, { median: number; q1: number; q3: number }>;
+    entropy?: Array<{ step: number; median: number; q1: number; q3: number }>;
+    actionHist?: Array<{ mid: number; median: number; err: [number, number] }>;
+  }>({});
   const [tab, setTab] = useState("overview");
 
   // Load persisted UI state per run
@@ -149,10 +173,151 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
     }
   };
 
-  const onLoad = () => reload();
+  const onLoad = async () => { await reload(); await loadArtifacts(); await loadSeedAggregates(); };
+
+  const loadArtifacts = async () => {
+    try {
+      const { data: art } = await api.get<RunArtifacts>(`/stockbot/runs/${runId}/artifacts`);
+      if (art?.metrics) {
+        try {
+          const { data: m } = await api.get<Metrics>(art.metrics, { baseURL: "" });
+          setMetrics(m);
+        } catch {
+          setMetrics(null);
+        }
+      } else {
+        setMetrics(null);
+      }
+      if (art?.equity) {
+        try {
+          const rows = await parseCSV(art.equity);
+          const eq = rows
+            .map((r: any, i: number) => ({ step: i, equity: Number(r.equity) }))
+            .filter((r: any) => Number.isFinite(r.step) && Number.isFinite(r.equity));
+          setEquity(eq);
+          const ddRows = drawdownFromEquity(rows).map((r: any, i: number) => ({ step: i, dd: -Number(r.dd) }));
+          setDrawdown(ddRows);
+        } catch {
+          setEquity([]); setDrawdown([]);
+        }
+      } else {
+        setEquity([]); setDrawdown([]);
+      }
+    } catch {
+      setMetrics(null); setEquity([]); setDrawdown([]);
+    }
+  };
+
+  const loadSeedAggregates = async () => {
+    try {
+      const base = runId.replace(/-seed\d+$/i, "");
+      const { data: allRuns } = await api.get<RunSummary[]>("/stockbot/runs");
+      const seeds = (allRuns || []).filter((r) => r.type === "train" && r.id.startsWith(base));
+      if (seeds.length <= 1) { setSeedAgg({}); return; }
+
+      const entropyTag = pickFirst(["train/entropy_loss", "train/entropy"], tags?.scalars || []);
+      const histTag = tags?.histograms?.find((t) => t.includes("actions")) || "actions/hist";
+
+      const metricsArr: Metrics[] = [];
+      const entropyArr: TBPoint[][] = [];
+      const histBuckets: Array<Array<[number, number, number]>> = [];
+
+      await Promise.all(
+        seeds.map(async (r) => {
+          try {
+            const { data: art } = await api.get<RunArtifacts>(`/stockbot/runs/${r.id}/artifacts`);
+            if (art?.metrics) {
+              const { data: m } = await api.get<Metrics>(art.metrics, { baseURL: "" });
+              metricsArr.push(m);
+            }
+            if (entropyTag) {
+              try {
+                const { data: sc } = await api.get<{ series: Record<string, TBPoint[]> }>(
+                  `/stockbot/runs/${r.id}/tb/scalars-batch`,
+                  { params: { tags: entropyTag } }
+                );
+                const s = sc.series?.[entropyTag];
+                if (s) entropyArr.push(s);
+              } catch {}
+            }
+            if (histTag) {
+              try {
+                const { data: h } = await api.get<{ tag: string; points: any[] }>(
+                  `/stockbot/runs/${r.id}/tb/histograms`,
+                  { params: { tag: histTag } }
+                );
+                const pts = h.points || [];
+                const last = pts[pts.length - 1];
+                if (last?.buckets) histBuckets.push(last.buckets);
+              } catch {}
+            }
+          } catch {}
+        })
+      );
+
+      const metricsAgg: Record<string, { median: number; q1: number; q3: number }> = {};
+      if (metricsArr.length) {
+        const keys: Array<keyof Metrics> = [
+          "total_return",
+          "max_drawdown",
+          "sharpe",
+          "sortino",
+          "calmar",
+          "turnover",
+        ];
+        keys.forEach((k) => {
+          const vals = metricsArr.map((m) => Number((m as any)[k])).filter((v) => Number.isFinite(v));
+          if (vals.length) metricsAgg[k as string] = statTriple(vals);
+        });
+      }
+
+      let entropyAgg: Array<{ step: number; median: number; q1: number; q3: number }> | undefined;
+      if (entropyArr.length) {
+        const map = new Map<number, number[]>();
+        entropyArr.forEach((arr) => {
+          arr.forEach((p) => {
+            const list = map.get(p.step) || [];
+            list.push(p.value);
+            map.set(p.step, list);
+          });
+        });
+        entropyAgg = Array.from(map.entries())
+          .sort((a, b) => a[0] - b[0])
+          .map(([step, vals]) => ({ step, ...statTriple(vals) }));
+      }
+
+      let histAgg: Array<{ mid: number; median: number; err: [number, number] }> | undefined;
+      if (histBuckets.length) {
+        const bucketMap = new Map<number, number[]>();
+        histBuckets.forEach((bks) => {
+          bks.forEach((b) => {
+            const mid = (Number(b[0]) + Number(b[1])) / 2;
+            const list = bucketMap.get(mid) || [];
+            list.push(Number(b[2]));
+            bucketMap.set(mid, list);
+          });
+        });
+        histAgg = Array.from(bucketMap.entries())
+          .sort((a, b) => a[0] - b[0])
+          .map(([mid, vals]) => {
+            const { median, q1, q3 } = statTriple(vals);
+            return { mid, median, err: [median - q1, q3 - median] };
+          });
+      }
+
+      setSeedAgg({ metrics: metricsAgg, entropy: entropyAgg, actionHist: histAgg });
+    } catch {
+      setSeedAgg({});
+    }
+  };
+
+  useEffect(() => { if (runId) loadArtifacts(); }, [runId]);
+  useEffect(() => { if (runId && tags) loadSeedAggregates(); }, [runId, tags]);
 
   const fmtStep = (s: number) => `${s}`;
   const fmtVal = (v: number) => Number.isFinite(v) ? v.toFixed(5) : "";
+  const fmtMetric = (k: string, v: number) =>
+    k === "total_return" || k === "max_drawdown" ? formatPct(v) : formatSigned(v);
 
   // cards builder
   const ChartCard = ({ title, tag, color }: { title: string; tag: string | null; color?: string }) => {
@@ -323,6 +488,47 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
           </div>
         )}
       </Card>
+      {metrics && equity.length > 0 && (
+        <Card className="p-4 space-y-3">
+          <TooltipLabel className="font-semibold" tooltip="Net-of-cost equity curve, drawdown and summary metrics.">
+            Net Performance
+          </TooltipLabel>
+          <div className="grid lg:grid-cols-2 gap-6">
+            <div className="h-56">
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={equity}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="step" tickFormatter={fmtStep} />
+                  <YAxis tickFormatter={(v: any) => String(v)} />
+                  <Tooltip labelFormatter={(l) => `step ${l}`} formatter={(v: any) => fmtVal(Number(v))} />
+                  <Line type="monotone" dataKey="equity" stroke="#10b981" dot={false} isAnimationActive={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="h-56">
+              <ResponsiveContainer width="100%" height="100%">
+                <AreaChart data={drawdown}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis dataKey="step" tickFormatter={fmtStep} />
+                  <YAxis tickFormatter={(v: any) => formatPct(v)} />
+                  <Tooltip labelFormatter={(l) => `step ${l}`} formatter={(v: any) => formatPct(Number(v))} />
+                  <Area type="monotone" dataKey="dd" stroke="#ef4444" fill="#fecaca" isAnimationActive={false} />
+                </AreaChart>
+              </ResponsiveContainer>
+            </div>
+          </div>
+          {metrics && (
+            <div className="grid md:grid-cols-3 gap-2 text-sm">
+              <div>Total Return: {formatPct(metrics.total_return)}</div>
+              <div>Sharpe: {formatSigned(metrics.sharpe)}</div>
+              <div>Max DD: {formatPct(metrics.max_drawdown)}</div>
+              <div>Sortino: {formatSigned(metrics.sortino)}</div>
+              <div>Calmar: {formatSigned(metrics.calmar)}</div>
+              <div>Turnover: {formatSigned(metrics.turnover)}</div>
+            </div>
+          )}
+        </Card>
+      )}
 
       {/* Distributions (Histograms) */}
       <Card className="p-4 space-y-3">
@@ -334,6 +540,65 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
         </div>
         {showDists && (
           <ActionsHistogramSection runId={runId} tags={tags} />
+      )}
+      </Card>
+
+      <Card className="p-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <TooltipLabel className="font-semibold" tooltip="Aggregate metrics across run seeds (median ± IQR).">
+            Seed Aggregate
+          </TooltipLabel>
+          <div className="text-sm"><label><input type="checkbox" checked={showSeed} onChange={(e)=>setShowSeed(e.target.checked)} /> Show</label></div>
+        </div>
+        {showSeed && (
+          <div className="space-y-4">
+            {seedAgg.metrics && (
+              <table className="text-sm w-full">
+                <thead>
+                  <tr><th className="text-left">Metric</th><th className="text-left">Median</th><th className="text-left">Q1–Q3</th></tr>
+                </thead>
+                <tbody>
+                  {Object.entries(seedAgg.metrics).map(([k,v]) => (
+                    <tr key={k}>
+                      <td className="pr-4 capitalize">{k.replace(/_/g, ' ')}</td>
+                      <td className="pr-4">{fmtMetric(k, v.median)}</td>
+                      <td>{fmtMetric(k, v.q1)} – {fmtMetric(k, v.q3)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+            {seedAgg.entropy && (
+              <div className="h-56">
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={seedAgg.entropy}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="step" tickFormatter={fmtStep} />
+                    <YAxis />
+                    <Tooltip labelFormatter={(l)=>`step ${l}`} formatter={(v:any)=>fmtVal(Number(v))} />
+                    <Line dataKey="median" stroke="#3b82f6" dot={false} />
+                    <Line dataKey="q1" stroke="#94a3b8" dot={false} strokeDasharray="4 4" />
+                    <Line dataKey="q3" stroke="#94a3b8" dot={false} strokeDasharray="4 4" />
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+            {seedAgg.actionHist && (
+              <div className="h-56">
+                <ResponsiveContainer width="100%" height="100%">
+                  <BarChart data={seedAgg.actionHist}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis dataKey="mid" tickFormatter={(v)=>Number(v).toFixed(2)} />
+                    <YAxis />
+                    <Tooltip formatter={(v:any)=>Number(v).toFixed(2)} />
+                    <Bar dataKey="median" isAnimationActive={false}>
+                      <ErrorBar dataKey="err" width={4} stroke="#1f2937" />
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            )}
+          </div>
         )}
       </Card>
 

--- a/stockbot/rl/metrics.py
+++ b/stockbot/rl/metrics.py
@@ -1,21 +1,67 @@
 from __future__ import annotations
 import numpy as np
 
+TRADING_DAYS = 252
+
+def _returns(equity_curve: np.ndarray, start_cash: float) -> np.ndarray:
+    """Simple return series from equity curve (assumes 1 step = 1 bar)."""
+    eq = np.asarray(equity_curve, dtype=np.float64)
+    if eq.size == 0:
+        return np.empty(0, dtype=np.float64)
+    eq0 = float(start_cash)
+    full = np.concatenate([[eq0], eq])
+    rets = np.diff(full) / max(eq0, 1e-9)
+    return rets
+
 def total_return(equity_curve: np.ndarray, start_cash: float) -> float:
-    if equity_curve.size == 0: return 0.0
+    if equity_curve.size == 0:
+        return 0.0
     return (float(equity_curve[-1]) - float(start_cash)) / float(start_cash)
 
 def max_drawdown(equity_curve: np.ndarray) -> float:
-    if equity_curve.size == 0: return 0.0
+    if equity_curve.size == 0:
+        return 0.0
     peaks = np.maximum.accumulate(equity_curve)
     dd = 1.0 - (equity_curve / np.maximum(peaks, 1e-9))
     return float(np.max(dd))
 
+def sharpe(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    r = _returns(equity_curve, start_cash)
+    if r.size < 2:
+        return 0.0
+    sd = r.std(ddof=0)
+    if sd < 1e-12:
+        return 0.0
+    return float(r.mean() / sd * np.sqrt(freq))
+
+def sortino(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    r = _returns(equity_curve, start_cash)
+    if r.size < 2:
+        return 0.0
+    downside = r[r < 0.0]
+    dd = downside.std(ddof=0)
+    if dd < 1e-12:
+        return 0.0
+    return float(r.mean() / dd * np.sqrt(freq))
+
+def cagr(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    if equity_curve.size == 0:
+        return 0.0
+    years = equity_curve.size / max(freq, 1)
+    gross = max(float(equity_curve[-1]) / max(start_cash, 1e-12), 1e-12)
+    return float(gross ** (1.0 / max(years, 1e-9)) - 1.0)
+
+def calmar(equity_curve: np.ndarray, start_cash: float, freq: int = TRADING_DAYS) -> float:
+    mdd = max_drawdown(equity_curve)
+    if mdd < 1e-12:
+        return 0.0
+    return float(cagr(equity_curve, start_cash, freq) / mdd)
+
+def turnover(turnover_steps: np.ndarray) -> float:
+    if turnover_steps.size == 0:
+        return 0.0
+    return float(np.sum(np.abs(turnover_steps)))
+
 def daily_sharpe(equity_curve: np.ndarray, start_cash: float) -> float:
-    """
-    Approximates 'daily' Sharpe by treating each step as one bar (e.g., 1d).
-    """
-    if equity_curve.size < 2: return 0.0
-    rets = np.diff(equity_curve) / max(start_cash, 1e-9)
-    if rets.std() < 1e-12: return 0.0
-    return float(rets.mean() / rets.std())
+    """Legacy alias of sharpe() using 1 step = 1 day."""
+    return sharpe(equity_curve, start_cash, freq=1)

--- a/stockbot/rl/smoke_test.py
+++ b/stockbot/rl/smoke_test.py
@@ -13,7 +13,7 @@ from stable_baselines3 import PPO
 
 from stockbot.env.config import EnvConfig
 from stockbot.rl.utils import make_env, Split, episode_rollout
-from stockbot.rl.metrics import total_return, max_drawdown, daily_sharpe
+from stockbot.rl.metrics import total_return, max_drawdown, sharpe, sortino, calmar, turnover
 
 def main():
     ap = argparse.ArgumentParser()
@@ -34,11 +34,14 @@ def main():
 
     from stockbot.env.config import EpisodeConfig
     start_cash = cfg.episode.start_cash if isinstance(cfg.episode, EpisodeConfig) else 100_000.0
-    curve = episode_rollout(eval_env, model, deterministic=True, seed=42)
+    curve, to = episode_rollout(eval_env, model, deterministic=True, seed=42)
     print("\n== Smoke Test Metrics (eval split) ==")
     print(f"TotalReturn: {total_return(curve, start_cash):+.3f}")
     print(f"MaxDrawdown: {max_drawdown(curve):.3f}")
-    print(f"Sharpe(d):   {daily_sharpe(curve, start_cash):.3f}")
+    print(f"Sharpe:      {sharpe(curve, start_cash):.3f}")
+    print(f"Sortino:     {sortino(curve, start_cash):.3f}")
+    print(f"Calmar:      {calmar(curve, start_cash):.3f}")
+    print(f"Turnover:    {turnover(to):.3f}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Visualize net-of-cost equity, drawdown and turnover in Training Results
- Aggregate run metrics across seeds to plot median ± IQR for KPIs, policy entropy and action histograms

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*
- `python -m py_compile stockbot/env/portfolio_env.py stockbot/rl/metrics.py stockbot/rl/utils.py stockbot/rl/train_ppo.py stockbot/rl/eval_agent.py stockbot/rl/smoke_test.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3c0e7bc288331b6d6bab931d881cd