### PR TITLE
Add walk-forward evaluation for HMM probabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,19 @@ setup_venv.bat  # Windows
 - **StockBot API**: Auto-generated docs at http://localhost:5002/docs
 - **Frontend**: Component documentation in source files
 
+## 📈 Walk-forward Probability Evaluation
+
+The `stockbot.prob.walkforward` module provides a small CLI for assessing
+the regime-switching model on rolling windows of historical returns. Run
+the evaluation with:
+
+```bash
+python -m stockbot.prob.walkforward data.json --train 200 --test 50 --states 2
+```
+
+The command prints per-fold log-likelihoods and the average log-loss across
+all folds. Input data can be supplied as JSON, CSV or plain text files.
+
 ## 🔐 Security Considerations
 
 - All sensitive data managed through Infisical

--- a/stockbot/prob/__init__.py
+++ b/stockbot/prob/__init__.py
@@ -9,6 +9,7 @@ CLI utilities.
 from .markov_states import MarkovStates, default_states
 from .estimation import fit_hmm, train_model
 from .inference import forward_filter, infer_sequence, load_model
+from .walkforward import evaluate_walkforward, split_walkforward
 
 __all__ = [
     "MarkovStates",
@@ -18,4 +19,6 @@ __all__ = [
     "forward_filter",
     "infer_sequence",
     "load_model",
+    "evaluate_walkforward",
+    "split_walkforward",
 ]

--- a/stockbot/prob/walkforward.py
+++ b/stockbot/prob/walkforward.py
@@ -1,0 +1,138 @@
+"""Walk-forward evaluation for regime-switching models.
+
+This module provides utilities to split a historical return series into
+rolling train/test windows and evaluate a Hidden Markov Model (HMM) on
+those folds. For each train/test split we fit a model using the existing
+:mod:`stockbot.prob` estimation utilities, run inference on the test
+segment and accumulate log-likelihood based metrics.
+
+The module exposes a simple command line interface so the evaluation can
+be executed as::
+
+    python -m stockbot.prob.walkforward data.json --train 200 --test 50 --states 2
+
+which will print a JSON blob containing per-fold log-likelihoods and the
+average log-loss across folds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import numpy as np
+
+from .estimation import train_model
+from .inference import _gaussian_pdf, infer_sequence, load_model
+
+
+# ---------------------------------------------------------------------------
+# Data helpers
+# ---------------------------------------------------------------------------
+
+def _load_series(path: str) -> List[float]:
+    p = Path(path)
+    if p.suffix.lower() == ".json":
+        return json.loads(p.read_text())
+    elif p.suffix.lower() in {".txt", ".csv"}:
+        return [float(x) for x in p.read_text().replace(",", " ").split() if x]
+    else:
+        raise ValueError("Unsupported file format")
+
+
+# ---------------------------------------------------------------------------
+# Walk-forward splitting
+# ---------------------------------------------------------------------------
+
+def split_walkforward(series: List[float], train_size: int, test_size: int) -> Iterable[Tuple[List[float], List[float]]]:
+    """Generate rolling train/test splits.
+
+    Parameters
+    ----------
+    series : list of float
+        Full historical return series.
+    train_size : int
+        Number of observations used for fitting.
+    test_size : int
+        Number of observations in each evaluation window.
+    """
+
+    limit = len(series) - train_size - test_size + 1
+    for start in range(0, max(limit, 0), test_size):
+        train = series[start : start + train_size]
+        test = series[start + train_size : start + train_size + test_size]
+        if len(test) == test_size:
+            yield train, test
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def _sequence_log_likelihood(series: List[float], transition: np.ndarray, emissions: List[Tuple[float, float]]) -> float:
+    """Compute the log-likelihood of a sequence under an HMM."""
+
+    m = len(emissions)
+    start = np.full(m, 1.0 / m)
+    alpha = start * np.array([_gaussian_pdf(series[0], *emissions[j]) for j in range(m)])
+    c = alpha.sum()
+    alpha /= c
+    log_likelihood = np.log(c)
+    for t in range(1, len(series)):
+        next_alpha = np.zeros(m)
+        for j in range(m):
+            emit = _gaussian_pdf(series[t], *emissions[j])
+            next_alpha[j] = emit * np.dot(alpha, transition[:, j])
+        c = next_alpha.sum()
+        next_alpha /= c
+        log_likelihood += np.log(c)
+        alpha = next_alpha
+    return float(log_likelihood)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+def evaluate_walkforward(series: List[float], train_size: int, test_size: int, n_states: int) -> Dict[str, object]:
+    """Run walk-forward evaluation and return metrics."""
+
+    folds: List[Dict[str, float]] = []
+    for train, test in split_walkforward(series, train_size, test_size):
+        with tempfile.TemporaryDirectory() as tmp:
+            train_model(train, n_states, tmp)
+            # Run inference to mirror production pipeline
+            infer_sequence(tmp, test)
+            transition, emissions, _ = load_model(tmp)
+            ll = _sequence_log_likelihood(test, transition, emissions)
+            folds.append({"log_likelihood": ll, "log_loss": -ll / len(test)})
+    avg_log_loss = float(np.mean([f["log_loss"] for f in folds])) if folds else float("nan")
+    return {"folds": folds, "avg_log_loss": avg_log_loss}
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Walk-forward evaluation of regime HMM")
+    parser.add_argument("data", help="Path to return series (json/csv)")
+    parser.add_argument("--train", type=int, required=True, help="Training window size")
+    parser.add_argument("--test", type=int, required=True, help="Test window size")
+    parser.add_argument("--states", type=int, default=2, help="Number of regimes")
+    parser.add_argument("--out", help="Optional path to save metrics JSON")
+    args = parser.parse_args()
+    series = _load_series(args.data)
+    metrics = evaluate_walkforward(series, args.train, args.test, args.states)
+    output = json.dumps(metrics, indent=2)
+    if args.out:
+        Path(args.out).write_text(output)
+    else:
+        print(output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/stockbot/tests/test_walkforward.py
+++ b/stockbot/tests/test_walkforward.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
+from stockbot.prob.walkforward import evaluate_walkforward
+
+
+def test_walkforward_eval():
+    series = [0.1, -0.2, 0.05, 0.03, -0.1, 0.2, 0.1, -0.05]
+    res = evaluate_walkforward(series, train_size=4, test_size=2, n_states=2)
+    assert "folds" in res and len(res["folds"]) == 2
+    assert res["avg_log_loss"] > 0
+    for fold in res["folds"]:
+        assert "log_likelihood" in fold
+        assert "log_loss" in fold


### PR DESCRIPTION
## Summary
- implement `stockbot.prob.walkforward` to split series into rolling train/test windows
- expose walk-forward evaluation utilities and CLI entry point
- document usage in README and add tests for evaluation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3cbe2a93083319b5972c2c18dae28