### PR TITLE
Add expected return and variance to probability inference

### DIFF
--- a/stockbot/api/controllers/prob_controller.py
+++ b/stockbot/api/controllers/prob_controller.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from pydantic import BaseModel
-from typing import List
+from typing import List, Dict
 
 from prob import train_model, infer_sequence
 
@@ -16,6 +16,13 @@ class ProbInferRequest(BaseModel):
     model_dir: str
 
 
+class ProbInferResponse(BaseModel):
+    posteriors: List[Dict[str, float]]
+    p_up: float
+    expected_return: float
+    variance: float
+
+
 def train(req: ProbTrainRequest) -> dict:
     out = Path(req.out_dir)
     out.mkdir(parents=True, exist_ok=True)
@@ -23,5 +30,6 @@ def train(req: ProbTrainRequest) -> dict:
     return {"out_dir": str(out)}
 
 
-def infer(req: ProbInferRequest) -> dict:
-    return infer_sequence(req.model_dir, req.series)
+def infer(req: ProbInferRequest) -> ProbInferResponse:
+    res = infer_sequence(req.model_dir, req.series)
+    return ProbInferResponse(**res)

--- a/stockbot/api/routes/prob_routes.py
+++ b/stockbot/api/routes/prob_routes.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from api.controllers.prob_controller import (
     ProbTrainRequest,
     ProbInferRequest,
+    ProbInferResponse,
     train,
     infer,
 )
@@ -15,6 +16,6 @@ async def train_endpoint(req: ProbTrainRequest):
     return train(req)
 
 
-@router.post("/infer")
+@router.post("/infer", response_model=ProbInferResponse)
 async def infer_endpoint(req: ProbInferRequest):
     return infer(req)

--- a/stockbot/prob/inference.py
+++ b/stockbot/prob/inference.py
@@ -74,4 +74,15 @@ def infer_sequence(model_dir: str, series: List[float]) -> Dict[str, Any]:
     next_state = np.dot(alpha[-1], transition)
     p_up_state = [_gaussian_cdf_pos(*e) for e in emissions]
     p_up = float(np.dot(next_state, p_up_state))
-    return {"posteriors": posteriors, "p_up": p_up}
+
+    means = np.array([e[0] for e in emissions])
+    variances = np.array([e[1] ** 2 for e in emissions])
+    expected_return = float(np.dot(next_state, means))
+    variance = float(np.dot(next_state, variances + means ** 2) - expected_return ** 2)
+
+    return {
+        "posteriors": posteriors,
+        "p_up": p_up,
+        "expected_return": expected_return,
+        "variance": variance,
+    }

--- a/stockbot/tests/test_prob.py
+++ b/stockbot/tests/test_prob.py
@@ -25,5 +25,12 @@ def test_train_and_infer(tmp_path):
     )
     assert res2.status_code == 200
     data = res2.json()
-    assert "posteriors" in data and "p_up" in data
+    assert (
+        "posteriors" in data
+        and "p_up" in data
+        and "expected_return" in data
+        and "variance" in data
+    )
     assert len(data["posteriors"]) == len(series)
+    assert isinstance(data["expected_return"], float)
+    assert isinstance(data["variance"], float)


### PR DESCRIPTION
## Summary
- extend `infer_sequence` to compute next-step expected return and variance
- expose these values via `/prob/infer` response model alongside `p_up`
- update tests for new fields

## Testing
- `pytest stockbot/tests/test_prob.py::test_train_and_infer -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3cbe217688331946c0966cdfb8ff5