### PR TITLE
Apply borrow fees to short positions

### DIFF
--- a/stockbot/Documentation/StockBot_Design_Document.md
+++ b/stockbot/Documentation/StockBot_Design_Document.md
@@ -94,13 +94,13 @@ Portfolio Env — `PortfolioTradingEnv`
   - `mapping_mode="tanh_leverage"`: fallback mapping where actions are `tanh()`-constrained weights with a gross leverage cap.
 - Execution & Brokerage:
   - Converts target weights to target shares based on prev close equity, builds `Order`s (market or limit), then simulates fills at next bar’s open using `ExecutionModel` and a `SimBroker` (adapter) with volume participation cap.
-  - Commissions and slippage applied per fill; financing on negative cash accrues via `Portfolio.step_interest()`.
+  - Commissions and slippage applied per fill; financing on negative cash and borrow on shorts accrue via `Portfolio.step_interest()`.
 - Reward: configurable base (`delta_nav` or `log_nav`) minus penalties: drawdown, turnover, rolling volatility, leverage cap breach.
 - Termination: end-of-data, horizon/max_steps, or equity stop (`stop_eq_frac`).
 
 Execution & Portfolio Models
 - `stockbot/env/execution.py:1`: Slippage and POV-constrained fills; limit order cross-checking vs (O,H,L,C); commission model.
-- `stockbot/env/portfolio.py:1`: Portfolio holdings, VWAP cost updates, cash movements, gross exposure, drawdown, interest on negative cash.
+  - `stockbot/env/portfolio.py:1`: Portfolio holdings, VWAP cost updates, cash movements, gross exposure, drawdown, interest on negative cash, and borrow fees on shorts.
 - `stockbot/env/orders.py:1`: `Order` and `Fill` data contracts.
 
 Key Files
@@ -259,7 +259,7 @@ Key Files
 
 **Risk, Execution & Market Microstructure**
 - Execution Model: Slippage bps around open for market orders, limit order crossing checks vs O/H/L/C, and participation-of-volume caps.
-- Financing: Negative cash accrues interest (borrow APR) each step scaled by bar interval.
+- Financing: Negative cash accrues interest and short positions incur borrow fees each step scaled by bar interval.
 - Reward Shaping: Penalties for drawdown, turnover, realized volatility, and leverage excess guide the policy to risk-aware behavior.
 - Circuit Breakers & Exposure: Placeholders in `stockbot/risk/` for portfolio-wide risk controls (circuit breakers, exposure validation) — ready for future extensions.
 

--- a/stockbot/env/portfolio.py
+++ b/stockbot/env/portfolio.py
@@ -16,6 +16,7 @@ class Portfolio:
     fees: FeeModel
     positions: Dict[str, Position] = field(default_factory=dict)
     equity_peak: float = 0.0
+    short_market_value: float = 0.0
 
     def value(self, prices: Dict[str,float]) -> float:
         pv = sum(pos.qty * prices[sym] for sym,pos in self.positions.items())
@@ -57,10 +58,19 @@ class Portfolio:
             # cash decreases on buy, increases on sell; always pay commission
             self.cash -= f.qty * f.price + f.commission
 
-    def step_interest(self, dt_years: float):
+    def step_interest(self, prices: Dict[str, float], dt_years: float):
         # charge interest on negative cash
         if self.cash < 0:
             self.cash *= (1.0 + self.margin.cash_borrow_apr * dt_years)
+
+        # borrow fees on short positions
+        self.short_market_value = sum(
+            -pos.qty * prices[sym]
+            for sym, pos in self.positions.items()
+            if pos.qty < 0
+        )
+        if self.short_market_value > 0:
+            self.cash -= self.short_market_value * self.fees.borrow_fee_apr * dt_years
 
     def update_peak(self, equity: float):
         self.equity_peak = max(self.equity_peak, equity)

--- a/stockbot/env/portfolio_env.py
+++ b/stockbot/env/portfolio_env.py
@@ -249,11 +249,11 @@ class PortfolioTradingEnv(gym.Env):
         # ---- advance to next bar
         self._i += 1
 
-        # ---- apply financing for this bar BEFORE valuing equity
-        self.port.step_interest(dt_years=self._dt_years())
-
         # ---- value portfolio at CLOSE[t]
         prices_close_t = self._prices(self._i - 1)  # CLOSE[t]
+
+        # ---- apply financing for this bar BEFORE valuing equity
+        self.port.step_interest(prices_close_t, dt_years=self._dt_years())
         eq_close_t = self.port.value(prices_close_t)
 
         # drawdown and metrics

--- a/stockbot/tests/test_borrow_fee.py
+++ b/stockbot/tests/test_borrow_fee.py
@@ -1,0 +1,71 @@
+import sys
+from pathlib import Path
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from stockbot.env.config import EnvConfig, FeeModel, MarginConfig, EpisodeConfig, FeatureConfig
+from stockbot.env.portfolio_env import PortfolioTradingEnv
+from stockbot.env.portfolio import Position
+
+
+class DummyPanel:
+    def __init__(self, df):
+        self.symbols = ["XYZ"]
+        self.panel = {"XYZ": df}
+        self.index = df.index
+        self._cols = list(df.columns)
+
+    def cols_required(self):
+        return self._cols
+
+
+def make_env():
+    idx = pd.date_range("2020-01-01", periods=3, freq="D")
+    data = {
+        "open": [100.0, 100.0, 100.0],
+        "high": [100.0, 100.0, 100.0],
+        "low": [100.0, 100.0, 100.0],
+        "close": [100.0, 100.0, 100.0],
+        "volume": [1000.0, 1000.0, 1000.0],
+    }
+    df = pd.DataFrame(data, index=idx)
+    panel = DummyPanel(df)
+    cfg = EnvConfig(
+        symbols=("XYZ",),
+        fees=FeeModel(
+            commission_per_share=0.0,
+            commission_pct_notional=0.0,
+            borrow_fee_apr=0.25,
+            slippage_bps=0.0,
+        ),
+        margin=MarginConfig(cash_borrow_apr=0.0),
+        episode=EpisodeConfig(
+            start_cash=1000.0,
+            lookback=1,
+            max_steps=1,
+            mapping_mode="tanh_leverage",
+        ),
+        features=FeatureConfig(use_custom_pipeline=False, indicators=()),
+    )
+    env = PortfolioTradingEnv(panel, cfg)
+    env.reset()
+    env.port.positions["XYZ"] = Position(qty=-1.0, avg_cost=100.0)
+    env.port.cash += 100.0  # proceeds from the short sale
+    return env
+
+
+def test_short_borrow_fee_affects_equity_and_reward():
+    env = make_env()
+    dt_years = 1.0 / 252.0
+    action = np.array([np.arctanh(-0.1)], dtype=np.float32)
+    _, reward, _, _, info = env.step(action)
+
+    short_val = 100.0
+    expected_cost = short_val * 0.25 * dt_years
+    assert env.port.short_market_value == pytest.approx(short_val)
+    assert env.port.cash == pytest.approx(1100.0 - expected_cost)
+    assert info["equity"] == pytest.approx(1000.0 - expected_cost)
+    assert reward == pytest.approx(-expected_cost / 1000.0)


### PR DESCRIPTION
## Summary
- charge borrow APR on short inventory in `Portfolio.step_interest`
- feed close prices into `PortfolioTradingEnv.step` so short borrow fees reduce equity
- document financing of short positions and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3cbd406948331b1f6861402565f2f