### PR TITLE
Add hybrid policy and evaluation harness

### DIFF
--- a/stockbot/rl/hybrid_policy.py
+++ b/stockbot/rl/hybrid_policy.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+"""Hybrid policy combining probabilistic sizing with PPO policy.
+
+The policy inspects the probability features present in the observation
+(`obs["prob"]`). When the predicted edge from the probability core is strong
+(either the next step probability of an up move exceeds ``prob_threshold`` or
+``mu/sigma`` is positive), the policy takes a deterministic action based on
+those features.  Otherwise it falls back to the provided PPO policy's action.
+
+This lightweight arbitration allows the agent to exploit whichever component
+currently offers a clearer signal.
+"""
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+import numpy as np
+
+
+@dataclass
+class HybridPolicy:
+    """Simple action arbitration between probability core and PPO policy."""
+
+    ppo_policy: Any
+    prob_threshold: float = 0.55
+    mu_sigma_threshold: float = 0.0
+
+    def reset(self) -> None:
+        if hasattr(self.ppo_policy, "reset"):
+            self.ppo_policy.reset()
+
+    def _prob_action(self, prob_vec: np.ndarray) -> np.ndarray:
+        """Size position purely from probability features."""
+        p_up = float(prob_vec[2]) if prob_vec.size > 2 else 0.5
+        mu_sigma = float(prob_vec[3]) if prob_vec.size > 3 else 0.0
+        if p_up > self.prob_threshold or mu_sigma > self.mu_sigma_threshold:
+            # Convert edge into [-1, 1] action. Positive edge -> long, negative -> short.
+            edge = p_up - 0.5
+            return np.array([np.clip(edge * 2.0, -1.0, 1.0)], dtype=np.float32)
+        return np.array([], dtype=np.float32)
+
+    def predict(
+        self,
+        obs: dict,
+        state: Optional[Tuple[np.ndarray, np.ndarray]] = None,
+        episode_start: Optional[np.ndarray] = None,
+        deterministic: bool = True,
+    ):
+        prob = obs.get("prob")
+        if prob is not None:
+            act = self._prob_action(prob)
+            if act.size:
+                return act, state
+        # Fallback to PPO
+        return self.ppo_policy.predict(obs, state, episode_start, deterministic)

--- a/stockbot/rl/run_wf.py
+++ b/stockbot/rl/run_wf.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+"""Simplified walk-forward evaluation harness for reinforcement-learning agents.
+
+The module drives multiple random seeds across a library of scenarios and
+collects metrics/curves for each run.  After all seeds have been evaluated, the
+results are aggregated and basic CI gates are applied.  The goal is to provide a
+lightweight yet extensible battery of tests to prevent overly fragile models
+from being promoted.
+"""
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
+from typing import Callable, Dict, Iterable, List, Tuple
+import json
+
+import numpy as np
+
+from .scenarios import Scenario, DEFAULT_SCENARIOS
+
+
+@dataclass
+class RunResult:
+    sharpe: float
+    drawdown: float
+    turnover: float
+
+
+RunFn = Callable[[Scenario, int], Tuple[Dict[str, float], np.ndarray, List, List]]
+
+
+def _save_outputs(run_dir: Path, metrics: Dict[str, float], equity: np.ndarray, orders: List, trades: List) -> None:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    (run_dir / "metrics.json").write_text(json.dumps(metrics, indent=2))
+    np.savetxt(run_dir / "equity.csv", equity, delimiter=",")
+    (run_dir / "orders.csv").write_text("" if not orders else "\n".join(map(str, orders)))
+    (run_dir / "trades.csv").write_text("" if not trades else "\n".join(map(str, trades)))
+
+
+def run_wf(
+    run_fn: RunFn,
+    scenarios: Dict[str, Scenario] | None = None,
+    seeds: Iterable[int] | None = None,
+    out_dir: str | Path = "wf_runs",
+    benchmark_sharpe: float = 1.0,
+    benchmark_drawdown: float = -0.2,
+    turnover_band: Tuple[float, float] = (0.0, 2.0),
+    pass_seeds: int = 3,
+) -> Dict[str, Dict[str, float | bool]]:
+    """Run walk-forward evaluation across scenarios and seeds."""
+    scenarios = scenarios or DEFAULT_SCENARIOS
+    seeds = list(seeds) if seeds is not None else list(range(5))
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    summary: Dict[str, Dict[str, float | bool]] = {}
+
+    for name, scenario in scenarios.items():
+        scen_dir = out_path / name
+        metrics_list: List[Dict[str, float]] = []
+        for seed in seeds:
+            metrics, equity, orders, trades = run_fn(scenario, seed)
+            metrics_list.append(metrics)
+            _save_outputs(scen_dir / f"seed{seed}", metrics, equity, orders, trades)
+
+        sharpe_vals = [m.get("sharpe", 0.0) for m in metrics_list]
+        dd_vals = [m.get("drawdown", 0.0) for m in metrics_list]
+        to_vals = [m.get("turnover", 0.0) for m in metrics_list]
+
+        med_sharpe = float(median(sharpe_vals)) if sharpe_vals else 0.0
+        med_dd = float(median(dd_vals)) if dd_vals else 0.0
+        med_to = float(median(to_vals)) if to_vals else 0.0
+
+        passes = sum(
+            (s >= benchmark_sharpe * 0.7)
+            and (d <= benchmark_drawdown + 0.20)
+            and (turnover_band[0] <= t <= turnover_band[1])
+            for s, d, t in zip(sharpe_vals, dd_vals, to_vals)
+        )
+        summary[name] = {
+            "median_sharpe": med_sharpe,
+            "median_drawdown": med_dd,
+            "median_turnover": med_to,
+            "passed": passes >= pass_seeds,
+        }
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Default dummy run function used for documentation/tests
+# ---------------------------------------------------------------------------
+
+def dummy_run_fn(scenario: Scenario, seed: int):
+    """Generate synthetic metrics for a scenario/seed pair.
+
+    This is intentionally lightweight so unit tests can exercise the harness
+    without heavy dependencies.  It simulates a geometric random walk with a
+    drift specified by the scenario.
+    """
+    rng = np.random.default_rng(seed)
+    returns = rng.normal(loc=scenario.drift, scale=0.01, size=100)
+    equity = np.cumprod(1.0 + returns)
+    sharpe = float(returns.mean() / (returns.std() + 1e-12) * np.sqrt(252))
+    drawdown = float((equity / np.maximum.accumulate(equity) - 1.0).min())
+    turnover = float(np.abs(returns).mean())
+    metrics = {"sharpe": sharpe, "drawdown": drawdown, "turnover": turnover}
+    return metrics, equity, [], []
+
+
+if __name__ == "__main__":  # pragma: no cover
+    summary = run_wf(dummy_run_fn)
+    print(json.dumps(summary, indent=2))

--- a/stockbot/rl/scenarios.py
+++ b/stockbot/rl/scenarios.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+"""Scenario definitions for evaluation harness.
+
+Each scenario specifies simple market conditions used during evaluation
+(backtests, walk-forward runs, etc.).  These definitions are intentionally
+minimal – real integrations can extend the fields as needed (slippage models,
+liquidity assumptions, etc.).
+"""
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(frozen=True)
+class Scenario:
+    name: str
+    drift: float = 0.0  # average return per step used by toy simulations
+    slippage_bps: float = 0.0
+    spread_bps: float = 0.0
+
+
+DEFAULT_SCENARIOS: Dict[str, Scenario] = {
+    "bull": Scenario("bull", drift=0.001),
+    "bear": Scenario("bear", drift=-0.001),
+    "sideways": Scenario("sideways", drift=0.0),
+}

--- a/stockbot/tests/test_hybrid_policy.py
+++ b/stockbot/tests/test_hybrid_policy.py
@@ -1,0 +1,21 @@
+import numpy as np
+
+from stockbot.rl.hybrid_policy import HybridPolicy
+
+
+class DummyPPO:
+    def predict(self, obs, state=None, episode_start=None, deterministic=True):
+        return np.array([0.3], dtype=np.float32), state
+
+
+def test_hybrid_policy_switch():
+    ppo = DummyPPO()
+    policy = HybridPolicy(ppo_policy=ppo, prob_threshold=0.55)
+
+    strong = {"prob": np.array([0.6, 0.4, 0.8, 1.0, 0.2], dtype=np.float32)}
+    act, _ = policy.predict(strong)
+    assert act[0] > 0.3  # probability core takes control
+
+    weak = {"prob": np.array([0.5, 0.5, 0.5, 0.0, 0.2], dtype=np.float32)}
+    act2, _ = policy.predict(weak)
+    assert np.allclose(act2[0], 0.3)

--- a/stockbot/tests/test_run_wf.py
+++ b/stockbot/tests/test_run_wf.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import numpy as np
+
+from stockbot.rl.run_wf import run_wf, Scenario
+
+
+def stable_run_fn(scenario: Scenario, seed: int):
+    # deterministic metrics that should pass the gates
+    returns = np.full(20, scenario.drift)
+    equity = np.cumprod(1 + returns)
+    metrics = {"sharpe": 1.0, "drawdown": -0.05, "turnover": 0.5}
+    orders = []
+    trades = []
+    return metrics, equity, orders, trades
+
+
+def test_run_wf(tmp_path: Path):
+    scenarios = {"bull": Scenario("bull", drift=0.01)}
+    summary = run_wf(
+        stable_run_fn,
+        scenarios=scenarios,
+        seeds=[0, 1, 2],
+        out_dir=tmp_path,
+        benchmark_sharpe=0.8,
+        benchmark_drawdown=-0.2,
+        turnover_band=(0.0, 1.0),
+        pass_seeds=2,
+    )
+    assert "bull" in summary and summary["bull"]["passed"]
+    run_dir = tmp_path / "bull" / "seed0"
+    assert run_dir.joinpath("metrics.json").exists()
+    assert run_dir.joinpath("equity.csv").exists()


### PR DESCRIPTION
## Summary
- extend trading environment and RL feature extractors with probability features
- add HybridPolicy for edge-based arbitration between probability core and PPO
- create scenario library and walk‑forward evaluation harness with CI gates

## Testing
- `cd stockbot && pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`

------
https://chatgpt.com/codex/tasks/task_e_68b4d91bb0a48331862dc562abf72c0f