### PR TITLE
Add SQLite run registry for experiment tracking

### DIFF
--- a/stockbot/run_registry.py
+++ b/stockbot/run_registry.py
@@ -1,0 +1,72 @@
+import json
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List
+
+class RunRegistry:
+    """Simple SQLite-backed registry for training/backtest runs."""
+
+    def __init__(self, db_path: Path):
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runs (
+                    id TEXT PRIMARY KEY,
+                    type TEXT,
+                    status TEXT,
+                    out_dir TEXT,
+                    created_at TEXT,
+                    started_at TEXT,
+                    finished_at TEXT,
+                    meta TEXT,
+                    error TEXT
+                )
+                """
+            )
+            conn.commit()
+
+    def save(self, rec: Any) -> None:
+        """Insert or update a run record."""
+        if hasattr(rec, "model_dump"):
+            data: Dict[str, Any] = rec.model_dump()
+        elif hasattr(rec, "dict"):
+            data = rec.dict()
+        else:
+            data = dict(rec)
+        meta = json.dumps(data.get("meta") or {})
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO runs
+                (id, type, status, out_dir, created_at, started_at, finished_at, meta, error)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    data.get("id"),
+                    data.get("type"),
+                    data.get("status"),
+                    data.get("out_dir"),
+                    data.get("created_at"),
+                    data.get("started_at"),
+                    data.get("finished_at"),
+                    meta,
+                    data.get("error"),
+                ),
+            )
+            conn.commit()
+
+    def list(self) -> List[Dict[str, Any]]:
+        with sqlite3.connect(self.db_path) as conn:
+            cur = conn.execute(
+                """
+                SELECT id, type, status, out_dir, created_at, started_at, finished_at
+                FROM runs ORDER BY datetime(created_at) DESC
+                """
+            )
+            cols = [col[0] for col in cur.description]
+            return [dict(zip(cols, row)) for row in cur.fetchall()]


### PR DESCRIPTION
## Summary
- Add RunRegistry to persist run metadata in a SQLite database
- Save run records from controller and expose persisted listing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4e3f707b48331b51b8842f760c070