### PR TITLE
feat: allow deleting training runs

### DIFF
--- a/frontend/src/api/stockbot.ts
+++ b/frontend/src/api/stockbot.ts
@@ -15,6 +15,10 @@ export async function downloadRunBundle(runId: string, includeModel = true): Pro
   return data as Blob;
 }
 
+export async function deleteRun(runId: string): Promise<void> {
+  await api.delete(`/stockbot/runs/${encodeURIComponent(runId)}`);
+}
+
 export async function getAiInsights() {
   const { data } = await api.get<{ insights: string[] }>('/stockbot/insights');
   return data;

--- a/frontend/src/components/Stockbot/Dashboard.tsx
+++ b/frontend/src/components/Stockbot/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
 import api from "@/api/client";
+import { deleteRun } from "@/api/stockbot";
 import { RunSummary } from "./lib/types";
 import StatusChip from "./shared/StatusChip";
 import {
@@ -12,6 +13,7 @@ import {
   saveRecentRuns,
   loadSavedRuns,
   toggleSavedRun,
+  saveSavedRuns,
 } from "./lib/runs";
 
 export default function Dashboard({
@@ -50,6 +52,21 @@ export default function Dashboard({
   const onToggleSave = (r: RunSummary) => {
     const next = toggleSavedRun(r);
     setSaved(next);
+  };
+
+  const onDelete = async (id: string) => {
+    if (!window.confirm("Delete this run?")) return;
+    try {
+      await deleteRun(id);
+      const nextRuns = runs.filter((r) => r.id !== id);
+      setRuns(nextRuns);
+      saveRecentRuns(nextRuns);
+      const nextSaved = saved.filter((r) => r.id !== id);
+      setSaved(nextSaved);
+      saveSavedRuns(nextSaved);
+    } catch (e) {
+      console.error(e);
+    }
   };
 
   return (
@@ -97,6 +114,9 @@ export default function Dashboard({
                   <Button size="sm" variant="outline" onClick={() => onToggleSave(r)}>
                     Save
                   </Button>
+                  <Button size="sm" variant="destructive" onClick={() => onDelete(r.id)}>
+                    Delete
+                  </Button>
                 </TableCell>
               </TableRow>
             ))}
@@ -138,6 +158,9 @@ export default function Dashboard({
                   </Button>
                   <Button size="sm" variant="outline" onClick={() => onToggleSave(r)}>
                     Remove
+                  </Button>
+                  <Button size="sm" variant="destructive" onClick={() => onDelete(r.id)}>
+                    Delete
                   </Button>
                 </TableCell>
               </TableRow>

--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -9,6 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { TooltipLabel } from "./shared/TooltipLabel";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import api from "@/api/client";
+import { deleteRun } from "@/api/stockbot";
 import type { RunSummary, Metrics, RunArtifacts } from "./lib/types";
 import { parseCSV, drawdownFromEquity } from "./lib/csv";
 import { formatPct, formatSigned } from "./lib/formats";
@@ -174,6 +175,19 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   };
 
   const onLoad = async () => { await reload(); await loadArtifacts(); await loadSeedAggregates(); };
+
+  const onDeleteRun = async () => {
+    if (!runId) return;
+    if (!window.confirm("Delete this run?")) return;
+    try {
+      await deleteRun(runId);
+      const next = runs.filter((r) => r.id !== runId);
+      setRuns(next);
+      setRunId(next[0]?.id || "");
+    } catch (e) {
+      console.error(e);
+    }
+  };
 
   const loadArtifacts = async () => {
     try {
@@ -474,6 +488,9 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
               className="w-48"
             />
             <Button size="sm" onClick={onLoad} disabled={!runId || loading}>{loading ? "Loading…" : "Load"}</Button>
+            <Button size="sm" variant="destructive" onClick={onDeleteRun} disabled={!runId || loading}>
+              Delete
+            </Button>
           </div>
           <div className="flex items-center gap-2 rounded border px-2 py-1">
             <TooltipLabel className="text-sm" tooltip="Automatically reload metrics">

--- a/stockbot/api/routes/stockbot_routes.py
+++ b/stockbot/api/routes/stockbot_routes.py
@@ -19,6 +19,7 @@ from api.controllers.stockbot_controller import (
     save_policy_upload,
     bundle_zip,
     cancel_run,
+    delete_run,
 )
 from api.controllers.insights_controller import InsightsRequest, generate_insights
 from api.controllers.highlights_controller import HighlightsRequest, generate_highlights
@@ -103,6 +104,11 @@ def get_run_tb_scalars_batch(run_id: str, tags: str, request: Request):
 @router.post("/runs/{run_id}/cancel")
 def post_cancel_run(run_id: str):
     return cancel_run(run_id)
+
+
+@router.delete("/runs/{run_id}")
+def delete_run_route(run_id: str):
+    return delete_run(run_id)
 
 
 # Optional: WebSocket live status (parallel to SSE stream)

--- a/stockbot/run_registry.py
+++ b/stockbot/run_registry.py
@@ -90,3 +90,9 @@ class RunRegistry:
             except Exception:
                 data["meta"] = {}
             return data
+
+    def delete(self, run_id: str) -> None:
+        """Remove a run record from the registry."""
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute("DELETE FROM runs WHERE id = ?", (run_id,))
+            conn.commit()


### PR DESCRIPTION
## Summary
- support removing runs from registry and filesystem
- expose delete run endpoint in API and UI
- add delete buttons on dashboard and training results screens
- centralize run deletion via frontend API helper

## Testing
- `pytest`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b515087d348331beace1ff4f7ffcdd