### PR TITLE
Add delete run endpoint

### DIFF
--- a/backend/controllers/stockbotController.js
+++ b/backend/controllers/stockbotController.js
@@ -60,6 +60,23 @@ export async function getRunProxy(req, res) {
   }
 }
 
+/** DELETE /api/stockbot/runs/:id */
+export async function deleteRunProxy(req, res) {
+  try {
+    const url = `${STOCKBOT_URL}/api/stockbot/runs/${encodeURIComponent(req.params.id)}`;
+    const { data } = await axios.delete(url);
+    // Some services may return an empty body; default to 204 in that case
+    if (data === undefined || data === null) {
+      return res.status(204).send();
+    }
+    return res.json(data);
+  } catch (e) {
+    const status = e.response?.status || 500;
+    const body = e.response?.data || { error: errMsg(e) };
+    return res.status(status).json(body);
+  }
+}
+
 /** GET /api/stockbot/runs/:id/artifacts */
 export async function getRunArtifactsProxy(req, res) {
   try {

--- a/backend/routes/stockbotRoutes.js
+++ b/backend/routes/stockbotRoutes.js
@@ -6,6 +6,7 @@ import {
   startBacktestProxy,
   listRunsProxy,
   getRunProxy,
+  deleteRunProxy,
   uploadPolicyProxy,
   getRunArtifactsProxy,
   getRunArtifactFileProxy,
@@ -42,6 +43,7 @@ router.get("/trade/status", protectRoute, getLiveTradingStatusProxy);
 // Query jobs
 router.get("/runs", protectRoute, listRunsProxy);
 router.get("/runs/:id", protectRoute, getRunProxy);
+router.delete("/runs/:id", protectRoute, deleteRunProxy);
 router.get("/runs/:id/artifacts", protectRoute, getRunArtifactsProxy);
 
 // Stream a specific artifact (metrics, equity, trades, orders, summary, config, model, job_log)


### PR DESCRIPTION
## Summary
- expose delete run proxy in stockbot controller and routes

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b518039cac8331b19647fa58d59e32