### PR TITLE
Fix gradient surface visualization in training results

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -2,6 +2,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import dynamic from "next/dynamic";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -46,6 +47,9 @@ const statTriple = (arr: number[]) => {
   const q3 = s[Math.floor((s.length - 1) * 3 / 4)];
   return { median, q1, q3 };
 };
+
+// Lazily load heavy Plotly component on the client only
+const PlotlySurface = dynamic(() => import("./PlotlySurface"), { ssr: false });
 
 export default function TrainingResults({ initialRunId }: { initialRunId?: string }) {
   const [runs, setRuns] = useState<RunSummary[]>([]);
@@ -437,8 +441,6 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   const epLenTag = useMemo(() => pickFirst(["rollout/ep_len_mean"], (tags?.scalars || available)), [tags, available]);
 
   // 3D Gradient Surface (Plotly)
-  // Render via factory wrapper to keep bundle light
-  const PlotlySurface = useMemo(() => require("./PlotlySurface").default, []);
   const gradientSurface = useMemo(() => {
     const gm = gradMatrix;
     if (!gm || !gm.layers?.length || !gm.steps?.length) return null;


### PR DESCRIPTION
## Summary
- Load Plotly 3D surface component with Next.js dynamic import so gradient diagnostics render again
- Remove obsolete require-based loader and keep gradient surface computation intact

## Testing
- `npm test` *(frontend: vitest not found)*
- `npm install --no-audit --no-fund` *(frontend: 403 Forbidden fetching dependencies)*
- `npm test` *(backend: vitest not found)*
- `npm install --no-audit --no-fund` *(backend: ENETUNREACH downloading Infisical CLI)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ba96e0608331b29d20967504a737