### PR TITLE
Wire P2 feature layer into env with manifest tracking

### DIFF
--- a/stockbot/api/controllers/stockbot_controller.py
+++ b/stockbot/api/controllers/stockbot_controller.py
@@ -402,6 +402,14 @@ async def start_train_job(req: TrainRequest, bg: BackgroundTasks):
     except Exception:
         pass
 
+    # Pre-build dataset manifest and observation schema using the P2 feature layer
+    try:
+        from stockbot.env.env_builder import prepare_env
+
+        prepare_env(req.model_dump(), out_dir)
+    except Exception as e:  # pragma: no cover - best effort only
+        print(f"[start_train_job] env prep failed: {e}")
+
     rec = RunRecord(
         id=run_id,
         type="train",

--- a/stockbot/env/env_builder.py
+++ b/stockbot/env/env_builder.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Tuple, Any
+import json
+
+from stockbot.ingestion.parquet_cache import ensure_parquet
+from stockbot.ingestion.dataset_manifest import build_manifest
+from stockbot.ingestion.feature_engineering import build_features
+from stockbot.features.builder import FeatureSpec
+
+
+def prepare_env(payload: Dict[str, Any], run_dir: str | Path) -> Tuple[Any, Dict[str, Any]]:
+    """Prepare windows + metadata for an env run and persist artifacts.
+
+    Parameters
+    ----------
+    payload: raw training payload from the UI/API.
+    run_dir: directory where run artifacts should be written.
+
+    Returns
+    -------
+    (windows, meta)
+        windows: np.ndarray shaped (T, lookback, N, F)
+        meta:    dict with keys like ``timestamps`` and ``symbols``.
+    """
+    run_path = Path(run_dir)
+    run_path.mkdir(parents=True, exist_ok=True)
+
+    ds = payload.get("dataset", {})
+    symbols = ds.get("symbols", ["AAA"])
+    interval = ds.get("interval", "1d")
+    adjusted = ds.get("adjusted_prices", True)
+    start = ds.get("start_date")
+    end = ds.get("end_date")
+
+    parquet_map = ensure_parquet(symbols, interval, adjusted, start, end)
+    manifest = build_manifest(symbols, interval, adjusted, start, end, ds.get("vendor", "test"), parquet_map)
+    (run_path / "dataset_manifest.json").write_text(json.dumps(manifest, indent=2))
+
+    feat = payload.get("features", {})
+    feature_set = feat.get("feature_set", ["ohlcv"])
+    if isinstance(feature_set, (list, tuple)):
+        feature_set = feature_set[0]
+    spec = FeatureSpec(
+        set=feature_set,
+        embargo_bars=feat.get("embargo_bars", 0),
+        normalize_obs=feat.get("normalize_observation", True),
+    )
+    lookback = ds.get("lookback", payload.get("lookback", 2))
+
+    windows, meta = build_features(parquet_map, lookback, spec)
+
+    # Observation schema is kept lightweight: shapes and dtypes only.
+    N = len(symbols)
+    F = windows.shape[-1] if windows.ndim == 4 else 0
+    schema = {
+        "window": {"dtype": str(windows.dtype), "shape": [lookback, N, F]},
+        "portfolio": {"dtype": "float32", "shape": [7 + N]},
+    }
+    (run_path / "obs_schema.json").write_text(json.dumps(schema, indent=2))
+
+    return windows, meta

--- a/stockbot/ingestion/feature_engineering.py
+++ b/stockbot/ingestion/feature_engineering.py
@@ -342,4 +342,12 @@ __all__ = [
     "create_labels",
     "create_sliding_windows",
     "prepare_dataset",
+    "build_features",
 ]
+
+
+# ---------------------------------------------------------------------
+# P2 feature builder re-export
+# ---------------------------------------------------------------------
+from stockbot.features.builder import FeatureSpec, build_features  # noqa: E402,F401
+


### PR DESCRIPTION
## Summary
- add `env_builder.prepare_env` to assemble features from parquet cache and persist dataset manifest & observation schema
- expose P2 `build_features` via ingestion module
- train job pre-builds dataset manifest/obs schema before launching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb6572c08483318b6d6b1ccb5d63c8