### PR TITLE
Add JSON export hooks for CV and stress tests

### DIFF
--- a/stockbot/reports/stress.py
+++ b/stockbot/reports/stress.py
@@ -1,13 +1,21 @@
 from typing import Dict, List
 
+import json
+
 from stockbot.pipeline import prepare_from_payload
 
 
-def run_stress_windows(model_path: str, payload: Dict, windows: List[Dict]) -> List[Dict]:
+def run_stress_windows(
+    model_path: str,
+    payload: Dict,
+    windows: List[Dict],
+    report_path: str | None = None,
+) -> List[Dict]:
     """Return placeholder KPIs for a list of stress-test windows.
 
     Each window triggers the P2 data-preparation pipeline so that stress tests
-    operate on the exact same feature construction code path as training.
+    operate on the exact same feature construction code path as training.  The
+    function returns the metrics and optionally writes them to ``report_path``.
     """
     report: List[Dict] = []
     for w in windows:
@@ -31,4 +39,9 @@ def run_stress_windows(model_path: str, payload: Dict, windows: List[Dict]) -> L
                 "notes": "",
             }
         )
+
+    if report_path is not None:
+        with open(report_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2)
+
     return report


### PR DESCRIPTION
## Summary
- Allow `run_purged_wf_cv` to persist cross-validation results
- Enable optional report writing for stress windows

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb6a6babfc83319048a534d674251d