### PR TITLE
feat: add sizing layers and live guardrails

### DIFF
--- a/stockbot/execution/__init__.py
+++ b/stockbot/execution/__init__.py
@@ -1,0 +1,15 @@
+from .live_guardrails import (
+    CanaryConfig,
+    CanaryState,
+    update_canary,
+    heartbeat_ok,
+    LiveGuardrails,
+)
+
+__all__ = [
+    "CanaryConfig",
+    "CanaryState",
+    "update_canary",
+    "heartbeat_ok",
+    "LiveGuardrails",
+]

--- a/stockbot/strategy/__init__.py
+++ b/stockbot/strategy/__init__.py
@@ -11,8 +11,11 @@ from .prob_policy import ProbPolicy
 from .sizing import (
     KellyConfig,
     VolTargetConfig,
+    SizingConfig,
+    SizingState,
     fractional_kelly_scalar,
     vol_target_scale,
+    apply_sizing_layers,
 )
 from .risk_layers import GuardsConfig, RiskState, apply_caps_and_guards
 from .regime_sizing import RegimeScalerConfig, regime_exposure_multiplier


### PR DESCRIPTION
## Summary
- implement Kelly and volatility targeting via `apply_sizing_layers`
- extend risk guards to enforce per-name, leverage, and daily loss limits
- integrate sizing & guard layers into `PortfolioTradingEnv` with trace/event logging
- provide `LiveGuardrails` for canary deployment and heartbeat checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb6cff0fc08331aa10590a7f6f73b2