### PR TITLE
feat: pass precomputed regime state into PPO env

### DIFF
--- a/stockbot/env/env_builder.py
+++ b/stockbot/env/env_builder.py
@@ -95,4 +95,9 @@ def prepare_env(payload: Dict[str, Any], run_dir: str | Path) -> Tuple[Any, Dict
         schema["gamma"] = {"dtype": "float32", "shape": [K]}
     (run_path / "obs_schema.json").write_text(json.dumps(schema, indent=2))
 
+    kelly = payload.get("sizing", {}).get("kelly", {})
+    state_scalars = kelly.get("state_scalars")
+    if state_scalars is not None:
+        (run_path / "state_scalars.json").write_text(json.dumps(state_scalars))
+
     return windows, meta


### PR DESCRIPTION
## Summary
- extend `make_env` to inject precomputed regime posteriors and scaling multipliers
- load regime metadata in `PPOTrainer` and forward into training/eval envs
- persist optional state scalars alongside observation schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bce01197f88331beb289eec5f95aaf