### PR TITLE
fix: use backend base URL for run artifacts

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -15,6 +15,7 @@ import type { RunSummary, Metrics, RunArtifacts } from "./lib/types";
 import { WeightsHeatmap } from "./NewTraining/WeightsHeatmap";
 import { RunChartsModal } from "./NewTraining/RunChartsModal";
 import { parseCSV, drawdownFromEquity } from "./lib/csv";
+import { buildUrl } from "@/api/client";
 import { formatPct, formatSigned } from "./lib/formats";
 import {
   ResponsiveContainer,
@@ -212,7 +213,7 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
       setArtifacts(art || null);
       if (art?.metrics) {
         try {
-          const { data: m } = await api.get<Metrics>(art.metrics, { baseURL: "" });
+          const { data: m } = await api.get<Metrics>(buildUrl(art.metrics));
           setMetrics(m);
         } catch {
           setMetrics(null);

--- a/frontend/src/components/Stockbot/lib/csv.ts
+++ b/frontend/src/components/Stockbot/lib/csv.ts
@@ -1,8 +1,10 @@
 // Tiny CSV reader (assumes header row, comma-separated, no quoted commas).
 // lib/csv.ts
+import { buildUrl } from "@/api/client";
+
 export async function parseCSV(url?: string | null): Promise<any[]> {
   if (!url) return [];
-  const res = await fetch(url, { cache: "no-store" });
+  const res = await fetch(buildUrl(url), { cache: "no-store" });
   if (!res.ok) return [];
   const text = await res.text();
   // Guard: if server returned HTML (404 page), bail out


### PR DESCRIPTION
## Summary
- ensure metrics and equity requests honor backend base URL
- resolve CSV fetches against backend base URL

## Testing
- `npm test` *(failed: Error downloading or extracting Infisical CLI: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcfa34294833196dd870930773197