### PR TITLE
feat: enable wheel scrolling for highlight card

### DIFF
--- a/frontend/src/components/overview/OverviewPage.tsx
+++ b/frontend/src/components/overview/OverviewPage.tsx
@@ -302,7 +302,9 @@ function HighlightCard({ title, items }: { title: string; items?: string[] }) {
       <CardContent>
         {items && items.length ? (
           <div>
-            <div className="overflow-y-auto pr-4" style={{ maxHeight: expanded ? '20rem' : '10rem' }}>
+            <ScrollArea
+              className={`pr-4 ${expanded ? "max-h-80" : "max-h-40"}`}
+            >
               <ul className="space-y-2 text-sm list-disc pl-4">
                 {items.map((item, i) => (
                   <li key={i} className="leading-relaxed">
@@ -310,7 +312,7 @@ function HighlightCard({ title, items }: { title: string; items?: string[] }) {
                   </li>
                 ))}
               </ul>
-            </div>
+            </ScrollArea>
             {items.length > 4 && (
               <Button
                 variant="ghost"


### PR DESCRIPTION
## Summary
- use ScrollArea for HighlightCard lists to support wheel scrolling

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68be46c2b8288331918e3ac2c0d65aba