### PR TITLE
feat: improve relevant events scrolling

### DIFF
--- a/frontend/src/components/overview/OverviewPage.tsx
+++ b/frontend/src/components/overview/OverviewPage.tsx
@@ -302,13 +302,13 @@ function HighlightCard({ title, items }: { title: string; items?: string[] }) {
         {items && items.length ? (
           <div>
             <div
-              className={`pr-4 overflow-y-auto ${
+              className={`pr-4 overflow-x-hidden overflow-y-hidden hover:overflow-y-auto ${
                 expanded ? "max-h-80" : "max-h-40"
               }`}
             >
               <ul className="space-y-2 text-sm list-disc pl-4">
                 {items.map((item, i) => (
-                  <li key={i} className="leading-relaxed">
+                  <li key={i} className="leading-relaxed break-words">
                     {item}
                   </li>
                 ))}


### PR DESCRIPTION
## Summary
- hide horizontal scrollbars and enable vertical scroll on hover in Relevant Events highlight card
- break long event text to avoid overflow

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be4cffe980833189a5d1f0ec2cf2d6