### PR TITLE
docs: update StockBot trading pipeline guide

### DIFF
--- a/docs/stockbot-trading-pipeline.md
+++ b/docs/stockbot-trading-pipeline.md
@@ -416,4 +416,16 @@ ignore this additional context or condition their allocations on the inferred ma
 from policy training the pipeline keeps the HMM transparent and interpretable while still giving reinforcement‑learning agents
 access to a higher‑level view of market dynamics.
 
+### Payload Preparation Helper
+
+The `stockbot.pipeline.prepare_from_payload` function ties together ingestion
+and feature generation into a single entry point. Given a training or
+backtesting request it ensures parquet caches via `ensure_parquet`,
+materializes a `dataset_manifest.json` with `build_manifest`, and builds the
+feature tensor using `FeatureSpec` and `build_features`. If regime parameters
+are provided it also fits an HMM and attaches posterior probabilities to the
+metadata. The helper returns the feature array and a metadata dictionary,
+allowing tests and higher‑level services to bootstrap runs without touching
+individual data-layer modules.
+
 


### PR DESCRIPTION
## Summary
- rename StockBot trading pipeline doc for README link compatibility
- document new `prepare_from_payload` helper that stitches ingestion and feature generation

## Testing
- `cd backend && npm test` *(fails: vitest not found)*
- `cd backend && npm install` *(fails: connect ENETUNREACH 140.82.113.4:443)*
- `cd stockbot && python -m pytest` *(fails: tests/test_borrow_fee.py::test_short_borrow_fee_affects_equity_and_reward, tests/test_p2_p4.py::test_cv_and_stress)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa213bcc4833188ee672083409243