### PR TITLE
feat: add jarvis text chat endpoint

### DIFF
--- a/stockbot/api/controllers/jarvis_controller.py
+++ b/stockbot/api/controllers/jarvis_controller.py
@@ -65,6 +65,18 @@ class ChatAskIn(BaseModel):
 class ChatAskOut(BaseModel):
     response: str
 
+
+# -----------------------------
+# Chat handlers
+# -----------------------------
+def chat_ask(
+    req: ChatAskIn,
+    service: JarvisService = Depends(get_jarvis_service),
+) -> ChatAskOut:
+    """Simple text chat endpoint."""
+    response = service.agent.generate(req.prompt, output_format=req.format)
+    return ChatAskOut(response=response)
+
 # DOM action models
 class WaitFor(BaseModel):
     op: Literal["wait_for"]

--- a/stockbot/api/routes/jarvis_routes.py
+++ b/stockbot/api/routes/jarvis_routes.py
@@ -19,6 +19,15 @@ router = APIRouter()
 
 #jarvis_service = JarvisService(llm_agent=ollama_agent)
 
+@router.post("/chat/ask", response_model=ctrl.ChatAskOut)
+def chat_ask(
+    req: ctrl.ChatAskIn,
+    service: JarvisService = Depends(ctrl.get_jarvis_service),
+):
+    # Pass the DI-injected service to the controller
+    return ctrl.chat_ask(req, service=service)
+
+
 @router.websocket("/voice/ws")
 async def jarvis_voice_ws(
     websocket: WebSocket,


### PR DESCRIPTION
## Summary
- add handler to relay text prompts to Jarvis agent
- expose new `/chat/ask` route for text-based interactions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `python -m uvicorn stockbot.server:app --port 8000` *(fails: No module named uvicorn)*

------
https://chatgpt.com/codex/tasks/task_e_68c21d5ea4b48331831e1c8f0c814241