### PR TITLE
Restore /api/jarvis/ask route in backend

### DIFF
--- a/backend/routes/jarvisRoutes.js
+++ b/backend/routes/jarvisRoutes.js
@@ -5,6 +5,7 @@ import {
   planJarvisEdit,
   proxyJarvisVoiceWs,
   fetchModels,
+  handleJarvisPrompt,
 } from "../controllers/jarvisController.js";
 
 export default function createJarvisRoutes(app) {
@@ -13,9 +14,9 @@ export default function createJarvisRoutes(app) {
   // =====================
   // TEXT + CONTROL ROUTES
   // =====================
-  /*router.post("/ask", protectRoute, handleJarvisPrompt);
+  router.post("/ask", protectRoute, handleJarvisPrompt);
 
-  router.post("/voice/start", protectRoute, startVoiceAssistant);
+  /*router.post("/voice/start", protectRoute, startVoiceAssistant);
   router.post("/voice/stop", protectRoute, stopVoiceAssistant);
   router.post("/voice/interrupt", protectRoute, interruptVoiceAssistant);
   router.get("/voice/status", protectRoute, getVoiceStatus);


### PR DESCRIPTION
## Summary
- restore POST /ask route in Jarvis router
- expose handleJarvisPrompt for Jarvis text requests

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm install` *(fails: Error downloading or extracting Infisical CLI: connect ENETUNREACH)*
- `npm run start:dev` *(fails: nodemon: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c22120083c8331b8e5b2a42e237d77