### PR TITLE
docs: expand trading pipeline walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The project consists of three interconnected services:
 - **Backend** – Node.js/Express API layer with MongoDB
 - **StockBot** – Python FastAPI service for trading logic and AI
 
-For a detailed walkthrough of how these components interact during training, backtesting, and live trading, see the [StockBot Trading Pipeline](docs/stockbot-trading-pipeline.md) guide.
+For a detailed walkthrough of how these components interact during training, backtesting, and live trading, see the [StockBot Trading Pipeline](docs/StockbotTradingPipeline.md) guide.
 
 ## ✨ Key Features
 


### PR DESCRIPTION
## Summary
- expand core system components with detailed data ingestion, training, and HMM regime notes
- append an in-depth walkthrough of the training pipeline including request schema, flow diagram, and step-by-step breakdown
- fix README link to the trading pipeline guide

## Testing
- `python -m pytest` (fails: FileNotFoundError: [Errno 2] No such file or directory: 'stockbot/env/env.example.yaml')

------
https://chatgpt.com/codex/tasks/task_e_68c455be34348331bcd6b8015d14bb31