### PR TITLE
Enable brokerless Jarvis insights in run monitor

### DIFF
--- a/backend/controllers/jarvisController.js
+++ b/backend/controllers/jarvisController.js
@@ -40,6 +40,28 @@ export const handleJarvisPrompt = async (req, res) => {
   }
 };
 
+// Simplified Jarvis prompt that does not require Schwab credentials
+export const handleJarvisPromptLite = async (req, res) => {
+  const { prompt, model, format } = req.body;
+  try { log.info({ prompt, model, format }, "Jarvis prompt lite"); } catch {}
+
+  if (!prompt || !model || !format) {
+    return res.status(400).json({ error: "Missing required fields." });
+  }
+
+  try {
+    const response = await axios.post(`${STOCKBOT_URL}/api/jarvis/chat/ask`, {
+      prompt,
+      model,
+      format,
+    });
+    res.json({ response: response.data.response });
+  } catch (error) {
+    console.error("🔴 Error forwarding to Jarvis FastAPI:", error.message);
+    res.status(500).json({ error: "Failed to get response from Jarvis." });
+  }
+};
+
 // Start voice assistant (client-driven)
 export const startVoiceAssistant = async (req, res) => {
   const { model, format } = req.body;

--- a/backend/routes/jarvisRoutes.js
+++ b/backend/routes/jarvisRoutes.js
@@ -6,6 +6,7 @@ import {
   proxyJarvisVoiceWs,
   fetchModels,
   handleJarvisPrompt,
+  handleJarvisPromptLite,
 } from "../controllers/jarvisController.js";
 
 export default function createJarvisRoutes(app) {
@@ -15,6 +16,7 @@ export default function createJarvisRoutes(app) {
   // TEXT + CONTROL ROUTES
   // =====================
   router.post("/ask", protectRoute, handleJarvisPrompt);
+  router.post("/ask-lite", protectRoute, handleJarvisPromptLite);
 
   /*router.post("/voice/start", protectRoute, startVoiceAssistant);
   router.post("/voice/stop", protectRoute, stopVoiceAssistant);

--- a/frontend/src/api/jarvisApi.ts
+++ b/frontend/src/api/jarvisApi.ts
@@ -33,6 +33,14 @@ export const askJarvis = async (prompt: string, user: User) => {
   return data;
 };
 
+// Lite prompt endpoint that does not require brokerage credentials
+export const askJarvisLite = async (prompt: string, user: User) => {
+  const model = user?.preferences?.model || 'llama3';
+  const format = user?.preferences?.format || 'markdown';
+  const { data } = await api.post('/jarvis/ask-lite', { prompt, model, format });
+  return data;
+};
+
 export async function getSchwabPortfolioData() {
   const { data } = await api.get('/jarvis/portfolio');
   return data;

--- a/frontend/src/components/Stockbot/RunMonitor.tsx
+++ b/frontend/src/components/Stockbot/RunMonitor.tsx
@@ -6,7 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import api, { buildUrl } from "@/api/client";
-import { askJarvis } from "@/api/jarvisApi";
+import { askJarvisLite } from "@/api/jarvisApi";
 import { formatPct, formatSigned } from "./lib/formats";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, ReferenceLine, ReferenceDot, Tooltip } from "recharts";
 
@@ -324,7 +324,7 @@ Data follows as labeled JSON/CSV snippets (trimmed).`;
     setAiError(null);
     try {
       const prompt = await buildRunPrompt();
-      const { response } = await askJarvis(prompt, { preferences: { model: 'llama3:8b', format: 'markdown' } } as any);
+      const { response } = await askJarvisLite(prompt, { preferences: { model: 'llama3:8b', format: 'markdown' } } as any);
       setAiText(String(response || ''));
     } catch (e: any) {
       setAiError(e?.message || 'Failed to get AI insights');


### PR DESCRIPTION
## Summary
- allow Jarvis prompts without Schwab credentials via new `/jarvis/ask-lite` route
- expose `askJarvisLite` client helper and use it in RunMonitor for AI insights

## Testing
- `cd backend && npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` in backend *(fails: connect ENETUNREACH 140.82.113.4:443)*
- `cd frontend && npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` in frontend *(fails: 403 Forbidden - GET https://registry.npmjs.org/react)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba5f8bd08331a50c087f785887f6