### PR TITLE
feat: add telemetry monitor skeleton

### DIFF
--- a/frontend/src/components/Stockbot/Results/Monitor/GlobalBrush.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/GlobalBrush.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { useGlobalBrush } from "./hooks/useGlobalBrush";
+
+export default function GlobalBrush() {
+  const { brush } = useGlobalBrush();
+  return (
+    <div className="border-t px-4 py-2 text-xs text-muted-foreground">
+      Global Brush: {brush.t0} – {brush.t1}
+    </div>
+  );
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/KpiStrip.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/KpiStrip.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Card } from "@/components/ui/card";
+import { Sparklines, SparklinesLine } from "react-sparklines";
+
+const KPIS = [
+  { key: "reward", label: "Net reward" },
+  { key: "steps", label: "Steps/sec" },
+  { key: "grad", label: "Grad norm" },
+  { key: "gpu", label: "GPU util" },
+  { key: "queue", label: "Queue fill %" },
+];
+
+export default function KpiStrip() {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 p-4 border-b">
+      {KPIS.map((k) => (
+        <Card key={k.key} className="p-2">
+          <div className="text-xs text-muted-foreground">{k.label}</div>
+          <div className="text-sm font-medium">—</div>
+          <Sparklines data={[0]} width={80} height={20}>
+            <SparklinesLine color="#8884d8" />
+          </Sparklines>
+        </Card>
+      ))}
+    </div>
+  );
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/MonitorDrawer.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/MonitorDrawer.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import MonitorHeader from "./MonitorHeader";
+import KpiStrip from "./KpiStrip";
+import GlobalBrush from "./GlobalBrush";
+import LiveTraining from "./sections/LiveTraining";
+import SystemHealth from "./sections/SystemHealth";
+import MarketContext from "./sections/MarketContext";
+import AlertsLogs from "./sections/AlertsLogs";
+import { GlobalBrushProvider } from "./hooks/useGlobalBrush";
+
+interface MonitorDrawerProps {
+  runId?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function MonitorDrawer({ runId, open, onOpenChange }: MonitorDrawerProps) {
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex flex-col w-full sm:max-w-md p-0">
+        <GlobalBrushProvider>
+          <MonitorHeader runId={runId} />
+          <KpiStrip />
+          <div className="flex-1 overflow-y-auto p-4 space-y-6">
+            <LiveTraining />
+            <SystemHealth />
+            <MarketContext />
+            <AlertsLogs />
+          </div>
+          <GlobalBrush />
+        </GlobalBrushProvider>
+      </SheetContent>
+    </Sheet>
+  );
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/MonitorHeader.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/MonitorHeader.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+export default function MonitorHeader({ runId }: { runId?: string }) {
+  return (
+    <div className="flex items-center justify-between border-b px-4 py-2">
+      <div className="font-semibold">Monitor {runId ? `- ${runId}` : ""}</div>
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="outline" disabled>
+          Pause
+        </Button>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/hooks/useGlobalBrush.ts
+++ b/frontend/src/components/Stockbot/Results/Monitor/hooks/useGlobalBrush.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import React, { createContext, useContext, useState } from "react";
+
+export type Brush = { t0: number; t1: number };
+
+const BrushContext = createContext<{
+  brush: Brush;
+  setBrush: React.Dispatch<React.SetStateAction<Brush>>;
+} | null>(null);
+
+export function GlobalBrushProvider({ children }: { children: React.ReactNode }) {
+  const [brush, setBrush] = useState<Brush>({ t0: 0, t1: 0 });
+  return <BrushContext.Provider value={{ brush, setBrush }}>{children}</BrushContext.Provider>;
+}
+
+export function useGlobalBrush() {
+  const ctx = useContext(BrushContext);
+  if (!ctx) throw new Error("useGlobalBrush must be used within GlobalBrushProvider");
+  return ctx;
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/hooks/useLiveStream.ts
+++ b/frontend/src/components/Stockbot/Results/Monitor/hooks/useLiveStream.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import { useEffect } from "react";
+
+export function useLiveStream(runId?: string) {
+  useEffect(() => {
+    if (!runId) return;
+    // Placeholder for SSE or WebSocket subscription
+  }, [runId]);
+
+  return { series: {}, alerts: [], logs: [] };
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/hooks/useRingSeries.ts
+++ b/frontend/src/components/Stockbot/Results/Monitor/hooks/useRingSeries.ts
@@ -1,0 +1,13 @@
+"use client";
+
+import React from "react";
+
+export function useRingSeries<T>(size = 600) {
+  const buffer = React.useRef<T[]>([]);
+  const push = (v: T) => {
+    buffer.current.push(v);
+    if (buffer.current.length > size) buffer.current.shift();
+  };
+  return { buffer: buffer.current, push };
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/sections/AlertsLogs.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/sections/AlertsLogs.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+export default function AlertsLogs() {
+  return (
+    <section>
+      <h3 className="font-medium mb-2">Alerts & Logs</h3>
+      <div className="text-sm text-muted-foreground">
+        Alert chips and searchable logs will appear here.
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/sections/LiveTraining.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/sections/LiveTraining.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+export default function LiveTraining() {
+  return (
+    <section>
+      <h3 className="font-medium mb-2">Live Training</h3>
+      <div className="text-sm text-muted-foreground">
+        Streaming reward, loss and gradient metrics will appear here.
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/sections/MarketContext.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/sections/MarketContext.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+export default function MarketContext() {
+  return (
+    <section>
+      <h3 className="font-medium mb-2">Market Context</h3>
+      <div className="text-sm text-muted-foreground">
+        Benchmark prices and realized volatility will appear here.
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/Stockbot/Results/Monitor/sections/SystemHealth.tsx
+++ b/frontend/src/components/Stockbot/Results/Monitor/sections/SystemHealth.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+export default function SystemHealth() {
+  return (
+    <section>
+      <h3 className="font-medium mb-2">System Health</h3>
+      <div className="text-sm text-muted-foreground">
+        Throughput, GPU and buffer metrics will appear here.
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -37,6 +37,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import MonitorDrawer from "./Results/Monitor/MonitorDrawer";
 
 type TBTags = { scalars: string[]; histograms: string[] };
 type TBPoint = { step: number; wall_time: number; value: number };
@@ -92,6 +93,7 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   }>({});
   const [tab, setTab] = useState("overview");
   const [runStatus, setRunStatus] = useState<RunSummary | null>(null);
+  const [monitorOpen, setMonitorOpen] = useState(false);
 
   // Keep runId in sync with parent prop if it changes (navigation)
   useEffect(() => {
@@ -590,9 +592,10 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
 
   return (
     <>
-    <div className="space-y-6">
-      <Card className="p-4 space-y-3">
-        <div className="flex flex-wrap items-center gap-3">
+      <MonitorDrawer runId={runId} open={monitorOpen} onOpenChange={setMonitorOpen} />
+      <div className="space-y-6">
+        <Card className="p-4 space-y-3">
+          <div className="flex flex-wrap items-center gap-3">
           <div className="text-lg font-semibold">Training Results</div>
           <div className="flex-1" />
           <div className="hidden md:block w-64">
@@ -628,6 +631,9 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
             </TooltipLabel>
             <Switch checked={autoRefresh} onCheckedChange={setAutoRefresh} />
           </div>
+          <Button size="sm" variant="secondary" onClick={() => setMonitorOpen(true)}>
+            Monitor
+          </Button>
         </div>
         {!!tags && (
           <div className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- add dockable monitor drawer with placeholder sections
- expose monitor button on training results
- scaffold hooks for global brush and streaming

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6138ec740833194ec595c36275f24