### PR TITLE
feat: add Jarvis history and trades endpoints

### DIFF
--- a/backend/controllers/jarvisController.js
+++ b/backend/controllers/jarvisController.js
@@ -190,6 +190,46 @@ export const getPortfolioData = async (req, res) => {
   }
 };
 
+// Retrieve conversation history from StockBot memory API
+export const getJarvisHistory = async (req, res) => {
+  try {
+    const accessToken = await refreshSchwabAccessTokenInternal(req.user._id);
+    if (!accessToken) {
+      return res.status(401).json({ error: "Failed to refresh Schwab token." });
+    }
+
+    const response = await axios.get(`${STOCKBOT_URL}/api/jarvis/history`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    const messages = response.data?.messages ?? response.data ?? [];
+    res.json({ messages });
+  } catch (error) {
+    console.error("🔴 Failed to get Jarvis history:", error.message);
+    res.status(500).json({ error: "Failed to get Jarvis history." });
+  }
+};
+
+// Retrieve recent trades from StockBot trading endpoint
+export const getJarvisTrades = async (req, res) => {
+  try {
+    const accessToken = await refreshSchwabAccessTokenInternal(req.user._id);
+    if (!accessToken) {
+      return res.status(401).json({ error: "Failed to refresh Schwab token." });
+    }
+
+    const response = await axios.get(`${STOCKBOT_URL}/api/jarvis/trades`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    const trades = response.data?.trades ?? response.data ?? [];
+    res.json({ trades });
+  } catch (error) {
+    console.error("🔴 Failed to get Jarvis trades:", error.message);
+    res.status(500).json({ error: "Failed to get Jarvis trades." });
+  }
+};
+
 export const fetchModels = async (req, res) => {
   try {
     const response = await axios.get('http://localhost:11434/api/tags');

--- a/backend/routes/jarvisRoutes.js
+++ b/backend/routes/jarvisRoutes.js
@@ -7,6 +7,8 @@ import {
   fetchModels,
   handleJarvisPrompt,
   handleJarvisPromptLite,
+  getJarvisHistory,
+  getJarvisTrades,
 } from "../controllers/jarvisController.js";
 
 export default function createJarvisRoutes(app) {
@@ -17,6 +19,8 @@ export default function createJarvisRoutes(app) {
   // =====================
   router.post("/ask", protectRoute, handleJarvisPrompt);
   router.post("/ask-lite", protectRoute, handleJarvisPromptLite);
+  router.get("/history", protectRoute, getJarvisHistory);
+  router.get("/trades", protectRoute, getJarvisTrades);
 
   /*router.post("/voice/start", protectRoute, startVoiceAssistant);
   router.post("/voice/stop", protectRoute, stopVoiceAssistant);

--- a/backend/server.js
+++ b/backend/server.js
@@ -88,6 +88,7 @@ async function startServer() {
     const server = https.createServer(sslOptions, app);
     expressWs(app, server);
 
+    // Jarvis routes include chat, history, trades and voice
     app.use("/api/jarvis", createJarvisRoutes(app));
     // WebSocket proxy to FastAPI for StockBot live status
     app.ws("/api/stockbot/runs/:id/ws", (client, req) => {
@@ -121,6 +122,7 @@ async function startServer() {
       const server = http.createServer(app);
       expressWs(app, server);
 
+      // Jarvis routes include chat, history, trades and voice
       app.use("/api/jarvis", createJarvisRoutes(app));
       app.ws("/api/stockbot/runs/:id/ws", (client, req) => {
         try {


### PR DESCRIPTION
## Summary
- add protected `/history` and `/trades` routes for Jarvis
- implement controller methods to proxy StockBot memory and trading APIs
- register Jarvis routes including history and trades in the server setup

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: connect ENETUNREACH 140.82.113.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_68c76df947e88331ab38f87af3bf6d35