### PR TITLE
Add memory management endpoints and short-term logging

### DIFF
--- a/stockbot/api/controllers/jarvis_controller.py
+++ b/stockbot/api/controllers/jarvis_controller.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 from jarvis.ws_handler import handle_voice_ws
 from jarvis.jarvis_service import JarvisService
 from jarvis.ollama_agent import OllamaAgent
-from jarvis.memory_manager import MemoryManager
+from jarvis.memory_manager import MemoryManager, Role
 from jarvis.huggingFace_agent import HuggingFaceAgent
 
 # -----------------------------
@@ -67,6 +67,10 @@ class ChatAskOut(BaseModel):
     response: str
 
 
+class UserIdIn(BaseModel):
+    user_id: str
+
+
 # -----------------------------
 # Chat handlers
 # -----------------------------
@@ -88,10 +92,14 @@ def chat_ask(
             old_model = None
 
     try:
+        uid = service.agent._pick_user_id(req.prompt) if hasattr(service.agent, '_pick_user_id') else 'default'
+        user_msg = service.agent._strip_user_tag(req.prompt) if hasattr(service.agent, '_strip_user_tag') else req.prompt
+        if req.use_memory is not False:
+            _mm.add_to_short_term(uid, Role.USER, user_msg)
+
         if req.use_memory is False:
             # Build a tools-only context without memory and avoid persisting the turn.
             try:
-                user_msg = req.prompt
                 # BaseAgent API
                 flags = service.agent.detect_flags(user_msg)
                 # Agent-specific helpers (present in both OllamaAgent and HuggingFaceAgent)
@@ -117,7 +125,7 @@ def chat_ask(
                 return ChatAskOut(response=raw)
             except Exception:
                 # Fallback: direct raw call without extra context
-                raw = service.agent._generate_raw(req.prompt, req.format or "text")  # type: ignore[attr-defined]
+                raw = service.agent._generate_raw(user_msg, req.format or "text")  # type: ignore[attr-defined]
                 return ChatAskOut(response=raw)
 
         # Default path: full memory-enabled generation
@@ -129,6 +137,29 @@ def chat_ask(
                 setattr(service.agent, 'model', old_model)
             except Exception:
                 pass
+
+
+def chat_history(
+    req: UserIdIn,
+    service: JarvisService = Depends(get_jarvis_service),
+) -> Dict[str, Any]:
+    return service.get_chat_history(req.user_id)
+
+
+def reset_memory(
+    req: UserIdIn,
+    service: JarvisService = Depends(get_jarvis_service),
+) -> Dict[str, str]:
+    service.reset_memory(req.user_id)
+    return {"status": "ok"}
+
+
+def summarize_memory(
+    req: UserIdIn,
+    service: JarvisService = Depends(get_jarvis_service),
+) -> Dict[str, Any]:
+    summary = service.summarize_memory(req.user_id)
+    return {"summary": summary}
 
 # DOM action models
 class WaitFor(BaseModel):

--- a/stockbot/api/routes/jarvis_routes.py
+++ b/stockbot/api/routes/jarvis_routes.py
@@ -28,6 +28,30 @@ def chat_ask(
     return ctrl.chat_ask(req, service=service)
 
 
+@router.post("/chat/history")
+def chat_history(
+    req: ctrl.UserIdIn,
+    service: JarvisService = Depends(ctrl.get_jarvis_service),
+):
+    return ctrl.chat_history(req, service=service)
+
+
+@router.post("/chat/reset")
+def chat_reset(
+    req: ctrl.UserIdIn,
+    service: JarvisService = Depends(ctrl.get_jarvis_service),
+):
+    return ctrl.reset_memory(req, service=service)
+
+
+@router.post("/chat/summarize")
+def chat_summarize(
+    req: ctrl.UserIdIn,
+    service: JarvisService = Depends(ctrl.get_jarvis_service),
+):
+    return ctrl.summarize_memory(req, service=service)
+
+
 @router.websocket("/voice/ws")
 async def jarvis_voice_ws(
     websocket: WebSocket,

--- a/stockbot/jarvis/huggingFace_agent.py
+++ b/stockbot/jarvis/huggingFace_agent.py
@@ -44,7 +44,7 @@ except Exception:
 # Project deps
 # -----------------------------------------
 from .agent import BaseAgent
-from .memory_manager import MemoryManager
+from .memory_manager import MemoryManager, Role
 from providers.provider_manager import ProviderManager
 from utils.web_search import fetch_financial_snippets
 
@@ -496,7 +496,7 @@ class HuggingFaceAgent(BaseAgent):
         final_prompt = self._truncate_prefill(final_prompt)
 
         reply = self._generate_raw(final_prompt, output_format)
-        self.memory_manager.add_turn(uid, user_msg, reply)
+        self.memory_manager.add_to_short_term(uid, Role.JARVIS, reply)
 
         if self.memory_manager.should_summarize(uid):
             self.memory_manager.summarize_short_term(
@@ -530,7 +530,7 @@ class HuggingFaceAgent(BaseAgent):
         finally:
             reply = "".join(full).strip()
             if reply:
-                self.memory_manager.add_turn(uid, user_msg, reply)
+                self.memory_manager.add_to_short_term(uid, Role.JARVIS, reply)
                 if self.memory_manager.should_summarize(uid):
                     asyncio.create_task(
                         self.memory_manager.summarize_short_term(

--- a/stockbot/jarvis/jarvis_service.py
+++ b/stockbot/jarvis/jarvis_service.py
@@ -74,3 +74,18 @@ class JarvisService:
     async def process_message(self, message: str):
         # This should now call the agent's generate method
         return self.agent.generate(message, output_format="text")
+
+    # Memory helpers -------------------------------------------------
+    def get_chat_history(self, user_id: str):
+        return self.agent.memory_manager.get_raw_memory(user_id)
+
+    def reset_memory(self, user_id: str):
+        self.agent.memory_manager.reset_memory(user_id)
+
+    def summarize_memory(self, user_id: str):
+        def _summarize_fn(prompt: str) -> str:
+            if hasattr(self.agent, "_generate_raw"):
+                return self.agent._generate_raw(prompt, "text")  # type: ignore[attr-defined]
+            return self.agent.generate(prompt, output_format="text")
+
+        return self.agent.memory_manager.summarize_short_term(user_id, _summarize_fn)

--- a/stockbot/jarvis/memory_manager.py
+++ b/stockbot/jarvis/memory_manager.py
@@ -169,6 +169,22 @@ class MemoryManager:
                 lines.append(f"You: {text}")
         return "\n".join(lines)
 
+    def add_to_short_term(self, user_id: str, role: Role | str, message: str):
+        """Append a single message to short-term memory and prune by token budget."""
+        log.debug(f"[Memory] add_to_short_term user_id={user_id} role={role}")
+        r = Role(role) if not isinstance(role, Role) else role
+        with self._lock:
+            self._load_user(user_id)
+            st: List[Tuple[Role, str]] = self._mem[user_id]["short_term"]  # type: ignore
+            st.append((r, message))
+
+            total_tokens = sum(self._count_tokens(msg) for _, msg in st)
+            while total_tokens > self.max_st_tokens and st:
+                removed_role, removed_msg = st.pop(0)
+                total_tokens -= self._count_tokens(removed_msg)
+
+            self._save_user(user_id)
+
     def add_turn(self, user_id: str, user_msg: str, jarvis_reply: str):
         """
         Append a (USER, msg) + (JARVIS, reply) turn and prune by token budget.

--- a/stockbot/jarvis/ollama_agent.py
+++ b/stockbot/jarvis/ollama_agent.py
@@ -8,7 +8,7 @@ import os
 from typing import Any, Dict, Optional, AsyncGenerator
 
 from .agent import BaseAgent
-from .memory_manager import MemoryManager
+from .memory_manager import MemoryManager, Role
 from providers.provider_manager import ProviderManager
 from utils.web_search import fetch_financial_snippets
 
@@ -198,8 +198,8 @@ class OllamaAgent(BaseAgent):
         # Fire a blocking Ollama call and get the full reply.
         reply = self._generate_raw(final_prompt, output_format)
 
-        # Persist conversation turn.
-        self.memory_manager.add_turn(uid, user_msg, reply)
+        # Append Jarvis reply to memory (user message handled upstream)
+        self.memory_manager.add_to_short_term(uid, Role.JARVIS, reply)
 
         # Periodically summarize to keep token budgets reasonable.
         if self.memory_manager.should_summarize(uid):
@@ -241,12 +241,17 @@ class OllamaAgent(BaseAgent):
 
         # Persist the stitched reply.
         reply = "".join(full).strip()
-        self.memory_manager.add_turn(uid, user_msg, reply)
-        
+        self.memory_manager.add_to_short_term(uid, Role.JARVIS, reply)
+
         # Run summarization without blocking the stream caller.
         if self.memory_manager.should_summarize(uid):
             print("[Jarvis] Triggering non-blocking background summarization.")
-            asyncio.create_task(self.memory_manager.summarize_short_term(uid, self))
+            asyncio.create_task(
+                self.memory_manager.summarize_short_term(
+                    uid,
+                    llm_summarize_fn=lambda p: self._generate_raw(p, "text")
+                )
+            )
         
         log.debug("[Jarvis] generate_stream() finished.")
 

--- a/stockbot/jarvis/ws_handler.py
+++ b/stockbot/jarvis/ws_handler.py
@@ -24,6 +24,7 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 
 # --- NEW: Import the diarization module ---
 from .diarization import SpeakerRegistry, SpeakerEmbedder
+from .memory_manager import Role
 
 # Load Silero VAD (PyTorch impl) and utilities from torch.hub
 VAD_MODEL, VAD_UTILS = torch.hub.load(
@@ -123,6 +124,12 @@ async def process_and_send_results(
     contextual_transcript = f"[Speaker {speaker_id}]: {transcript}"
     conn_history.append({"role": "user", "content": contextual_transcript})
     await websocket.send_text(json.dumps({"event": "transcript", "data": transcript, "speaker": f"Speaker {speaker_id}"}))
+
+    try:
+        uid = getattr(jarvis_service.agent, "_user_id", "default")
+        jarvis_service.agent.memory_manager.add_to_short_term(uid, Role.USER, contextual_transcript)
+    except Exception:
+        pass
 
     # Local helper to synthesize and send TTS audio in a cancel-aware way
     async def flush_tts_phrase(text: str):


### PR DESCRIPTION
## Summary
- add `add_to_short_term` to MemoryManager and expose memory helpers in JarvisService
- log user messages from chat and voice to short-term memory
- provide endpoints to fetch, reset and summarize chat memory

## Testing
- `pytest` *(fails: assert 199.99998474121094 == 100.0 ± 1.0e-04)*

------
https://chatgpt.com/codex/tasks/task_e_68c76dfd41cc8331923e5e60bea1b704