### PR TITLE
feat: integrate openwebui component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "kokoro-js": "^1.2.1",
     "lucide-react": "^0.539.0",
     "next": "15.4.2",
+    "open-webui": "latest",
     "plotly.js-dist-min": "^2.35.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/frontend/src/app/openwebui/OpenWebUI.tsx
+++ b/frontend/src/app/openwebui/OpenWebUI.tsx
@@ -1,79 +1,25 @@
 'use client';
 
-import { useState } from 'react';
-import { askJarvis, askJarvisLite } from '@/api/jarvisApi';
+import dynamic from 'next/dynamic';
 import { useProfile } from '@/api/user';
 
-interface Message {
-  id: number;
-  role: 'user' | 'assistant';
-  content: string;
-}
+// Dynamically import the official OpenWebUI component
+// @ts-expect-error - module provided at runtime
+const OpenWebUIRoot = dynamic(() => import('open-webui'), { ssr: false });
 
 export default function OpenWebUI() {
   const { data: profile } = useProfile();
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [input, setInput] = useState('');
-  const [sending, setSending] = useState(false);
 
-  const sendPrompt = async (useLite = true) => {
-    if (!input.trim()) return;
-    const prompt = input;
-    setMessages((prev) => [...prev, { id: Date.now(), role: 'user', content: prompt }]);
-    setInput('');
-    setSending(true);
-    try {
-      const fn = useLite ? askJarvisLite : askJarvis;
-      const res = await fn(prompt, profile || {});
-      const reply = res?.response ?? '';
-      setMessages((prev) => [...prev, { id: Date.now() + 1, role: 'assistant', content: reply }]);
-    } catch (err: any) {
-      setMessages((prev) => [
-        ...prev,
-        { id: Date.now() + 1, role: 'assistant', content: err?.message || 'Request failed' },
-      ]);
-    } finally {
-      setSending(false);
-    }
-  };
+  const token =
+    (profile as any)?.token ||
+    (profile as any)?.accessToken ||
+    (profile as any)?.authToken;
 
   return (
-    <div className="flex flex-col h-full max-h-screen">
-      <div className="flex-1 overflow-y-auto p-4 space-y-2 bg-base-200">
-        {messages.map((m) => (
-          <div key={m.id} className={m.role === 'user' ? 'text-right' : 'text-left'}>
-            <div
-              className={`inline-block px-3 py-2 rounded-lg ${
-                m.role === 'user' ? 'bg-primary text-primary-content' : 'bg-base-100'
-              }`}
-            >
-              {m.content}
-            </div>
-          </div>
-        ))}
-      </div>
-      <div className="p-4 border-t flex gap-2">
-        <input
-          className="input input-bordered flex-1"
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              sendPrompt(true);
-            }
-          }}
-          placeholder="Type a prompt..."
-        />
-        <button
-          className="btn btn-primary"
-          onClick={() => sendPrompt(true)}
-          disabled={sending}
-        >
-          Send
-        </button>
-      </div>
-    </div>
+    <OpenWebUIRoot
+      apiUrl={`${process.env.NEXT_PUBLIC_BACKEND_URL}/api/jarvis`}
+      authToken={token}
+    />
   );
 }
 

--- a/frontend/src/types/openwebui.d.ts
+++ b/frontend/src/types/openwebui.d.ts
@@ -1,0 +1,11 @@
+import { ComponentType } from 'react';
+
+declare module 'open-webui' {
+  interface OpenWebUIProps {
+    apiUrl?: string;
+    authToken?: string;
+  }
+  const OpenWebUI: ComponentType<OpenWebUIProps>;
+  export default OpenWebUI;
+}
+


### PR DESCRIPTION
## Summary
- replace bespoke chat UI with OpenWebUI root component and forward auth token
- declare OpenWebUI module typings and expose API endpoint via NEXT_PUBLIC_BACKEND_URL/api/jarvis
- add open-webui dependency placeholder

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/open-webui)*

------
https://chatgpt.com/codex/tasks/task_e_68c7737d6ad88331b2733ae439b5f6a2