### PR TITLE
Fix nonfunctional run table scroll and add custom training JSON option

### DIFF
--- a/frontend/src/components/Stockbot/Dashboard.tsx
+++ b/frontend/src/components/Stockbot/Dashboard.tsx
@@ -103,8 +103,8 @@ export default function Dashboard({
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <Card className="p-4">
           <h3 className="text-lg font-semibold mb-3">Training Runs</h3>
-          <div className="max-h-96 overflow-auto">
-            <Table containerClassName="max-h-96">
+          <ScrollArea className="h-96">
+            <Table containerClassName="overflow-visible">
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Run ID</TableHead>
@@ -146,13 +146,13 @@ export default function Dashboard({
                 )}
               </TableBody>
             </Table>
-          </div>
+          </ScrollArea>
         </Card>
 
         <Card className="p-4">
           <h3 className="text-lg font-semibold mb-3">Backtests</h3>
-          <div className="max-h-96 overflow-auto">
-            <Table containerClassName="max-h-96">
+          <ScrollArea className="h-96">
+            <Table containerClassName="overflow-visible">
               <TableHeader className="sticky top-0 bg-background z-10">
                 <TableRow>
                   <TableHead>Run ID</TableHead>
@@ -193,14 +193,14 @@ export default function Dashboard({
                 )}
               </TableBody>
             </Table>
-          </div>
+          </ScrollArea>
         </Card>
       </div>
 
       <Card className="p-4">
         <h3 className="text-lg font-semibold mb-3">Saved Runs</h3>
-        <div className="max-h-96 overflow-auto">
-          <Table containerClassName="max-h-96">
+        <ScrollArea className="h-96">
+          <Table containerClassName="overflow-visible">
             <TableHeader className="sticky top-0 bg-background z-10">
             <TableRow>
               <TableHead>Run ID</TableHead>
@@ -243,7 +243,7 @@ export default function Dashboard({
             )}
           </TableBody>
           </Table>
-        </div>
+        </ScrollArea>
       </Card>
     </div>
   );

--- a/frontend/src/components/Stockbot/NewTraining/index.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/index.tsx
@@ -19,6 +19,9 @@ import { SizingSection, DEFAULT_SIZING } from "./SizingSection";
 import { RewardLoggingSection, DEFAULT_REWARD  } from "./RewardLoggingSection";
 import { DownloadsSection } from "./DownloadsSection";
 import { buildTrainPayload, type TrainPayload } from "./payload";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 
 const TERMINAL: Array<JobStatusResponse["status"]> = ["SUCCEEDED", "FAILED", "CANCELLED"];
 const ppoDivisible = (n: number, b: number) => n > 0 && b > 0 && n % b === 0;
@@ -128,6 +131,10 @@ export default function NewTraining({
   const [saveTb, setSaveTb] = useState(true);
   const [saveActions, setSaveActions] = useState(true);
   const [saveRegime, setSaveRegime] = useState(true);
+
+  // ===== Advanced JSON =====
+  const [useJson, setUseJson] = useState(false);
+  const [jsonPayload, setJsonPayload] = useState("");
 
   // ===== Run state =====
   const [jobId, setJobId] = useState<string | null>(null);
@@ -303,6 +310,82 @@ export default function NewTraining({
     } catch {}
   };
 
+  const gatherState = () => ({
+    symbols: symbols.split(",").map((s) => s.trim()).join(","),
+    start,
+    end,
+    interval,
+    adjusted,
+    lookback,
+    trainSplit,
+    featureSet,
+    dataSource,
+    rsi,
+    macd,
+    bbands,
+    normalizeObs,
+    embargo,
+    commissionPerShare,
+    takerFeeBps,
+    makerRebateBps,
+    halfSpreadBps,
+    impactK,
+    fillPolicy,
+    vwapMinutes,
+    maxParticipation,
+    cvFolds,
+    cvEmbargo,
+    regimeEnabled,
+    regimeStates,
+    regimeFeatures,
+    appendBeliefs,
+    policy,
+    totalTimesteps,
+    nSteps,
+    batchSize,
+    learningRate,
+    gamma,
+    gaeLambda,
+    clipRange,
+    entCoef,
+    vfCoef,
+    maxGradNorm,
+    dropout,
+    seed,
+    mappingMode,
+    investMax,
+    grossLevCap,
+    maxStepChange,
+    rebalanceEps,
+    minHoldBars,
+    kellyEnabled,
+    kellyLambda,
+    kellyFMax,
+    kellyEmaAlpha,
+    volEnabled,
+    volTarget,
+    volMin,
+    clampMin,
+    clampMax,
+    dailyLoss,
+    perNameCap,
+    rewardBase,
+    wDrawdown,
+    wTurnover,
+    wVol,
+    wLeverage,
+    saveTb,
+    saveActions,
+    saveRegime,
+  });
+
+  useEffect(() => {
+    if (useJson) {
+      setJsonPayload(JSON.stringify(buildTrainPayload(gatherState()), null, 2));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [useJson]);
+
   // ===== Submit =====
   const onSubmit = async () => {
     setSubmitting(true);
@@ -333,74 +416,20 @@ export default function NewTraining({
     }
 
     try {
-      const payload: TrainPayload = buildTrainPayload({
-        symbols: symbols.split(",").map(s => s.trim()).join(","), // normalize
-        start,
-        end,
-        interval,
-        adjusted,
-        lookback,
-        trainSplit,
-        featureSet,
-        dataSource,
-        rsi,
-        macd,
-        bbands,
-        normalizeObs,
-        embargo,
-        commissionPerShare,
-        takerFeeBps,
-        makerRebateBps,
-        halfSpreadBps,
-        impactK,
-        fillPolicy,
-        vwapMinutes,
-        maxParticipation,
-        cvFolds,
-        cvEmbargo,
-        regimeEnabled,
-        regimeStates,
-        regimeFeatures,
-        appendBeliefs,
-        policy,
-        totalTimesteps,
-        nSteps,
-        batchSize,
-        learningRate,
-        gamma,
-        gaeLambda,
-        clipRange,
-        entCoef,
-        vfCoef,
-        maxGradNorm,
-        dropout,
-        seed,
-        mappingMode,
-        investMax,
-        grossLevCap,
-        maxStepChange,
-        rebalanceEps,
-        minHoldBars,
-        kellyEnabled,
-        kellyLambda,
-        kellyFMax,
-        kellyEmaAlpha,
-        volEnabled,
-        volTarget,
-        volMin,
-        clampMin,
-        clampMax,
-        dailyLoss,
-        perNameCap,
-        rewardBase,
-        wDrawdown,
-        wTurnover,
-        wVol,
-        wLeverage,
-        saveTb,
-        saveActions,
-        saveRegime,
-      });
+      const state = gatherState();
+      let payload: TrainPayload;
+      if (useJson && jsonPayload.trim()) {
+        try {
+          payload = JSON.parse(jsonPayload);
+        } catch {
+          setError("Invalid JSON payload");
+          setSubmitting(false);
+          setProgress(null);
+          return;
+        }
+      } else {
+        payload = buildTrainPayload(state);
+      }
 
       const { data: resp } = await api.post<{ job_id: string }>("/stockbot/train", payload);
       if (!resp?.job_id) throw new Error("No job_id returned");
@@ -455,6 +484,20 @@ export default function NewTraining({
         </div>
       )}
       {error && <div className="text-sm text-red-600">{error}</div>}
+
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Switch id="use-json" checked={useJson} onCheckedChange={setUseJson} />
+          <Label htmlFor="use-json">Edit JSON payload</Label>
+        </div>
+        {useJson && (
+          <Textarea
+            className="font-mono text-xs h-64"
+            value={jsonPayload}
+            onChange={(e) => setJsonPayload(e.target.value)}
+          />
+        )}
+      </div>
 
       <Accordion type="multiple" className="w-full">
         <DatasetSection


### PR DESCRIPTION
## Summary
- Wrap run, backtest, and saved run tables in ScrollArea so their scrollbars work
- Allow editing a JSON payload for new training jobs and send it directly to the backend

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c7746c23448331a4c1ddd2124c7938