### PR TITLE
feat: allow custom eval window from UI

### DIFF
--- a/docs/StockbotTradingPipeline.md
+++ b/docs/StockbotTradingPipeline.md
@@ -160,6 +160,7 @@ The frontend posts `TrainRequest` (pydantic models in `stockbot/api/controllers/
   - `lookback` (int): observation window (mirrors `episode.lookback`).
   - `train_eval_split` ("last_year"|"80_20"|"custom_ranges")
   - `custom_ranges` (optional array of ranges)
+  - `eval_window_days` (optional int): override eval window length (calendar days)
 
 - `features` (FeaturesModel)
   - `feature_set` (list): e.g., ["ohlcv_ta_basic"]

--- a/frontend/src/components/Stockbot/NewTraining/DatasetSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/DatasetSection.tsx
@@ -19,6 +19,8 @@ interface DatasetProps {
   setAdjusted: (v: boolean) => void;
   lookback: number;
   setLookback: (v: number) => void;
+  evalWindow: number;
+  setEvalWindow: (v: number) => void;
   trainEvalSplit: string;
   setTrainEvalSplit: (v: string) => void;
 }
@@ -36,6 +38,8 @@ export function DatasetSection({
   setAdjusted,
   lookback,
   setLookback,
+  evalWindow,
+  setEvalWindow,
   trainEvalSplit,
   setTrainEvalSplit,
 }: DatasetProps) {
@@ -77,6 +81,13 @@ export function DatasetSection({
             tooltip="Number of past bars provided in each observation"
             value={String(lookback)}
             onChange={(v) => setLookback(parseInt(v) || lookback)}
+            type="number"
+          />
+          <InputGroup
+            label="Eval Window"
+            tooltip="Calendar days for evaluation window (0=auto)"
+            value={String(evalWindow)}
+            onChange={(v) => setEvalWindow(parseInt(v) || 0)}
             type="number"
           />
           <div className="flex flex-col gap-1">

--- a/frontend/src/components/Stockbot/NewTraining/index.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/index.tsx
@@ -40,6 +40,7 @@ export default function NewTraining({
   const [interval, setInterval] = useState<"1d" | "1h" | "15m">("1d");
   const [adjusted, setAdjusted] = useState(true);
   const [lookback, setLookback] = useState(64);
+  const [evalWindow, setEvalWindow] = useState(0);
   const [trainSplit, setTrainSplit] = useState("last_year");
 
   // ===== Features =====
@@ -317,6 +318,7 @@ export default function NewTraining({
     interval,
     adjusted,
     lookback,
+    evalWindow,
     trainSplit,
     featureSet,
     dataSource,
@@ -513,6 +515,8 @@ export default function NewTraining({
           setAdjusted={setAdjusted}
           lookback={lookback}
           setLookback={setLookback}
+          evalWindow={evalWindow}
+          setEvalWindow={setEvalWindow}
           trainEvalSplit={trainSplit}
           setTrainEvalSplit={setTrainSplit}
         />

--- a/frontend/src/components/Stockbot/NewTraining/payload.ts
+++ b/frontend/src/components/Stockbot/NewTraining/payload.ts
@@ -8,6 +8,7 @@ export interface TrainPayload {
     lookback: number;
     train_eval_split: "last_year" | "80_20" | "custom_ranges";
     custom_ranges?: { train: [string, string]; eval: [string, string] }[];
+    eval_window_days?: number;
   };
   features: {
     feature_set: ("ohlcv" | "ohlcv_ta_basic" | "ohlcv_ta_rich")[];
@@ -97,6 +98,7 @@ export function buildTrainPayload(state: any): TrainPayload {
       adjusted_prices: !!state.adjusted,
       lookback: Number(state.lookback) || 64,
       train_eval_split: state.trainSplit || 'last_year',
+      eval_window_days: Number(state.evalWindow) || undefined,
     },
     features: {
       feature_set: state.featureSet,

--- a/stockbot/api/controllers/stockbot_controller.py
+++ b/stockbot/api/controllers/stockbot_controller.py
@@ -115,6 +115,7 @@ class DatasetModel(BaseModel):
     lookback: int = 64
     train_eval_split: Literal["last_year", "80_20", "custom_ranges"] = "last_year"
     custom_ranges: Optional[List[Dict[str, List[str]]]] = None
+    eval_window_days: Optional[int] = None
 
 
 class FeaturesModel(BaseModel):
@@ -344,6 +345,8 @@ def _env_snapshot_from_train(req: "TrainRequest") -> Dict[str, Any]:
     base["start"] = ds.start_date
     base["end"] = ds.end_date
     base["adjusted"] = bool(ds.adjusted_prices)
+    if getattr(ds, "eval_window_days", None) is not None:
+        base["eval_window_days"] = int(ds.eval_window_days)
 
     # Episode lookback
     base.setdefault("episode", {})

--- a/stockbot/env/config.py
+++ b/stockbot/env/config.py
@@ -96,6 +96,7 @@ class EnvConfig:
     start: str = "2018-01-01"
     end: str = "2022-12-31"
     adjusted: bool = True
+    eval_window_days: Optional[int] = None
 
     fees: FeeModel = FeeModel()
     margin: MarginConfig = MarginConfig()
@@ -133,6 +134,7 @@ class EnvConfig:
             start=d.get("start", "2018-01-01"),
             end=d.get("end", "2022-12-31"),
             adjusted=bool(d.get("adjusted", True)),
+            eval_window_days=d.get("eval_window_days"),
 
             fees=mk(FeeModel, "fees"),
             margin=mk(MarginConfig, "margin"),

--- a/stockbot/rl/train_utils.py
+++ b/stockbot/rl/train_utils.py
@@ -14,36 +14,47 @@ def to_dt(s: str) -> datetime:
 
 
 def infer_split_from_cfg(cfg: EnvConfig) -> Split:
-    """Train/eval split inference (calendar-year or 80/20)."""
+    """Train/eval split inference with optional eval window override."""
     start = to_dt(cfg.start)
     end = to_dt(cfg.end)
 
-    span_days = (end - start).days
-    if span_days < 365:
-        split_point = start + timedelta(days=int(span_days * 0.8))
-        train = (start.strftime("%Y-%m-%d"), split_point.strftime("%Y-%m-%d"))
-        eval_ = (
-            (split_point + timedelta(days=1)).strftime("%Y-%m-%d"),
-            end.strftime("%Y-%m-%d"),
-        )
-        return Split(train=train, eval=eval_)
+    eval_window = getattr(cfg, "eval_window_days", None)
+    if eval_window:
+        eval_start = end - timedelta(days=int(eval_window) - 1)
+        if eval_start < start:
+            eval_start = start
+        train_end = eval_start - timedelta(days=1)
+        if train_end < start:
+            train_end = start
+        train = (start.strftime("%Y-%m-%d"), train_end.strftime("%Y-%m-%d"))
+        eval_ = (eval_start.strftime("%Y-%m-%d"), end.strftime("%Y-%m-%d"))
+    else:
+        span_days = (end - start).days
+        if span_days < 365:
+            split_point = start + timedelta(days=int(span_days * 0.8))
+            train = (start.strftime("%Y-%m-%d"), split_point.strftime("%Y-%m-%d"))
+            eval_ = (
+                (split_point + timedelta(days=1)).strftime("%Y-%m-%d"),
+                end.strftime("%Y-%m-%d"),
+            )
+            return Split(train=train, eval=eval_)
 
-    last_year = end.year
-    eval_start = datetime(last_year, 1, 1)
-    eval_end = end
-    train_end = eval_start - timedelta(days=1)
+        last_year = end.year
+        eval_start = datetime(last_year, 1, 1)
+        eval_end = end
+        train_end = eval_start - timedelta(days=1)
 
-    if start.year >= last_year:
-        split_point = start + timedelta(days=int(span_days * 0.8))
-        train = (start.strftime("%Y-%m-%d"), split_point.strftime("%Y-%m-%d"))
-        eval_ = (
-            (split_point + timedelta(days=1)).strftime("%Y-%m-%d"),
-            end.strftime("%Y-%m-%d"),
-        )
-        return Split(train=train, eval=eval_)
+        if start.year >= last_year:
+            split_point = start + timedelta(days=int(span_days * 0.8))
+            train = (start.strftime("%Y-%m-%d"), split_point.strftime("%Y-%m-%d"))
+            eval_ = (
+                (split_point + timedelta(days=1)).strftime("%Y-%m-%d"),
+                end.strftime("%Y-%m-%d"),
+            )
+            return Split(train=train, eval=eval_)
 
-    train = (start.strftime("%Y-%m-%d"), train_end.strftime("%Y-%m-%d"))
-    eval_ = (eval_start.strftime("%Y-%m-%d"), eval_end.strftime("%Y-%m-%d"))
+        train = (start.strftime("%Y-%m-%d"), train_end.strftime("%Y-%m-%d"))
+        eval_ = (eval_start.strftime("%Y-%m-%d"), eval_end.strftime("%Y-%m-%d"))
 
     # Ensure the eval window has enough calendar days to fetch bars; if not,
     # back off to a rolling tail window ending at `end`.

--- a/stockbot/strategy/sizing.py
+++ b/stockbot/strategy/sizing.py
@@ -95,10 +95,12 @@ def apply_sizing_layers(
         cfg.state.realized_var_ewma = (
             (1 - cfg.vol_ema_alpha) * prev + cfg.vol_ema_alpha * (r ** 2)
         )
+        realized_vol = float(np.sqrt(cfg.state.realized_var_ewma) * np.sqrt(252))
+        vol_scale = vol_target_scale(realized_vol, cfg.vol_target)
     else:
         f = 1.0
-    realized_vol = float(np.sqrt(cfg.state.realized_var_ewma) * np.sqrt(252))
-    vol_scale = vol_target_scale(realized_vol, cfg.vol_target)
+        vol_scale = 1.0
+        realized_vol = 0.0
 
     w = w_raw * f * vol_scale * float(gamma_t)
     trace = {


### PR DESCRIPTION
## Summary
- allow datasets to specify `eval_window_days`
- wire eval window through API, config, and split inference
- expose evaluation window field in training form
- ignore vol target scaling until returns are available

## Testing
- `pytest -q`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c776fbaa1c8331a9ae1b89ec354648