### PR TITLE
Propagate eval window through UI payload

### DIFF
--- a/frontend/src/components/Stockbot/NewTraining/payload.ts
+++ b/frontend/src/components/Stockbot/NewTraining/payload.ts
@@ -8,7 +8,7 @@ export interface TrainPayload {
     lookback: number;
     train_eval_split: "last_year" | "80_20" | "custom_ranges";
     custom_ranges?: { train: [string, string]; eval: [string, string] }[];
-    eval_window_days?: number;
+    eval_window_days: number;
   };
   features: {
     feature_set: ("ohlcv" | "ohlcv_ta_basic" | "ohlcv_ta_rich")[];
@@ -98,7 +98,7 @@ export function buildTrainPayload(state: any): TrainPayload {
       adjusted_prices: !!state.adjusted,
       lookback: Number(state.lookback) || 64,
       train_eval_split: state.trainSplit || 'last_year',
-      eval_window_days: Number(state.evalWindow) || undefined,
+      eval_window_days: Number(state.evalWindow) || 0,
     },
     features: {
       feature_set: state.featureSet,

--- a/stockbot/api/controllers/stockbot_controller.py
+++ b/stockbot/api/controllers/stockbot_controller.py
@@ -345,7 +345,7 @@ def _env_snapshot_from_train(req: "TrainRequest") -> Dict[str, Any]:
     base["start"] = ds.start_date
     base["end"] = ds.end_date
     base["adjusted"] = bool(ds.adjusted_prices)
-    if getattr(ds, "eval_window_days", None) is not None:
+    if getattr(ds, "eval_window_days", None):
         base["eval_window_days"] = int(ds.eval_window_days)
 
     # Episode lookback


### PR DESCRIPTION
## Summary
- Always include `eval_window_days` in training payload from UI
- Skip writing `eval_window_days` to config when not set

## Testing
- `pytest -q`
- `npm test --silent` *(fails: vitest: not found)*
- `npm run lint --silent` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c77abd70ec833180038d391e9b6c36