### PR TITLE
Validate dataset rows and support eval window payload

### DIFF
--- a/frontend/src/components/Stockbot/NewTraining/payload.ts
+++ b/frontend/src/components/Stockbot/NewTraining/payload.ts
@@ -8,7 +8,7 @@ export interface TrainPayload {
     lookback: number;
     train_eval_split: "last_year" | "80_20" | "custom_ranges";
     custom_ranges?: { train: [string, string]; eval: [string, string] }[];
-    eval_window_days: number;
+    eval_window_days?: number;
   };
   features: {
     feature_set: ("ohlcv" | "ohlcv_ta_basic" | "ohlcv_ta_rich")[];
@@ -98,7 +98,10 @@ export function buildTrainPayload(state: any): TrainPayload {
       adjusted_prices: !!state.adjusted,
       lookback: Number(state.lookback) || 64,
       train_eval_split: state.trainSplit || 'last_year',
-      eval_window_days: Number(state.evalWindow) || 0,
+      ...(state.trainSplit === 'custom_ranges' && state.customRanges
+        ? { custom_ranges: state.customRanges }
+        : {}),
+      ...(state.evalWindow ? { eval_window_days: Number(state.evalWindow) } : {}),
     },
     features: {
       feature_set: state.featureSet,

--- a/stockbot/api/controllers/stockbot_controller.py
+++ b/stockbot/api/controllers/stockbot_controller.py
@@ -545,9 +545,26 @@ async def start_train_job(req: TrainRequest, bg: BackgroundTasks):
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"Failed to build env snapshot: {e}")
     _dump_yaml(env_snapshot, snapshot_path)
+
+    # Validate dataset upfront so the user receives immediate feedback on
+    # insufficient rows, rather than failing deep in training.
+    try:
+        from stockbot.env.config import EnvConfig
+        from stockbot.env.data_adapter import PanelSource
+        from stockbot.ingestion.yfinance_ingestion import YFinanceProvider
+
+        cfg = EnvConfig(**env_snapshot)
+        prov = YFinanceProvider()
+        PanelSource(prov, cfg)
+    except RuntimeError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Dataset validation failed: {e}")
+
+    payload_dict = req.model_dump(exclude_none=True)
     payload_path = Path(out_dir) / "payload.json"
     try:
-        payload_path.write_text(json.dumps(req.model_dump(), indent=2))
+        payload_path.write_text(json.dumps(payload_dict, indent=2))
     except Exception:
         pass
 
@@ -558,13 +575,13 @@ async def start_train_job(req: TrainRequest, bg: BackgroundTasks):
 
         # Non-blocking: schedule as background task. Training can start immediately.
         # The trainer will proceed even if these artifacts are not ready yet.
-        bg.add_task(prepare_env, req.model_dump(), out_dir)
+        bg.add_task(prepare_env, payload_dict, out_dir)
     except Exception as e:  # pragma: no cover - best effort only
         print(f"[start_train_job] env prep scheduling failed: {e}")
 
     # augment meta with dataset manifest hash if present
     meta = {
-        "payload": req.model_dump(),
+        "payload": payload_dict,
         "config_snapshot": str(snapshot_path),
         "payload_path": str(payload_path),
     }


### PR DESCRIPTION
## Summary
- validate dataset rows before launching training and omit nulls from payload snapshots
- allow frontend payload to specify optional eval_window_days or custom_ranges

## Testing
- `pytest`
- `cd frontend && npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7842915008331b683b997fb52f60d