### PR TITLE
Add custom date range support for training splits

### DIFF
--- a/stockbot/api/controllers/stockbot_controller.py
+++ b/stockbot/api/controllers/stockbot_controller.py
@@ -7,7 +7,7 @@ import subprocess
 import zipfile
 from tempfile import NamedTemporaryFile
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, List, Optional, Dict, Literal
 import secrets
 import yaml
@@ -337,7 +337,27 @@ def _env_snapshot_from_train(req: "TrainRequest") -> Dict[str, Any]:
     Starts from env.example.yaml and overlays UI selections so YFinance-based
     training uses the requested symbols/dates/costs/features/sizing.
     """
-    base = _load_yaml("stockbot/env/env.example.yaml");
+    base = _load_yaml("stockbot/env/env.example.yaml")
+    # Drop legacy top-level sections from the template so that generated
+    # snapshots only contain the flattened EnvConfig schema.  Keeping the
+    # original groups (e.g. ``dataset`` or ``costs``) led to confusing
+    # duplicates in ``config.snapshot.yaml`` where stale defaults appeared
+    # alongside the flattened overrides.  Training only consumes the
+    # flattened form, so strip the unused groups to avoid misinterpretation.
+    for k in (
+        "dataset",
+        "features",
+        "costs",
+        "execution_model",
+        "cv",
+        "stress_windows",
+        "regime",
+        "model",
+        "sizing",
+        "reward",
+        "artifacts",
+    ):
+        base.pop(k, None)
 
     ds = req.dataset
     base["symbols"] = list(ds.symbols)
@@ -345,8 +365,30 @@ def _env_snapshot_from_train(req: "TrainRequest") -> Dict[str, Any]:
     base["start"] = ds.start_date
     base["end"] = ds.end_date
     base["adjusted"] = bool(ds.adjusted_prices)
-    if getattr(ds, "eval_window_days", None):
+    if ds.eval_window_days is not None:
         base["eval_window_days"] = int(ds.eval_window_days)
+    # Support explicit custom ranges or derive one from eval_window_days
+    if ds.train_eval_split == "custom_ranges":
+        if ds.custom_ranges:
+            base["custom_ranges"] = ds.custom_ranges
+        elif ds.eval_window_days is not None:
+            try:
+                end_dt = datetime.fromisoformat(ds.end_date)
+                start_dt = datetime.fromisoformat(ds.start_date)
+                eval_start = end_dt - timedelta(days=int(ds.eval_window_days) - 1)
+                if eval_start < start_dt:
+                    eval_start = start_dt
+                train_end = eval_start - timedelta(days=1)
+                if train_end < start_dt:
+                    train_end = start_dt
+                base["custom_ranges"] = [
+                    {
+                        "train": [start_dt.strftime("%Y-%m-%d"), train_end.strftime("%Y-%m-%d")],
+                        "eval": [eval_start.strftime("%Y-%m-%d"), end_dt.strftime("%Y-%m-%d")],
+                    }
+                ]
+            except Exception:
+                pass
 
     # Episode lookback
     base.setdefault("episode", {})

--- a/stockbot/env/config.py
+++ b/stockbot/env/config.py
@@ -97,6 +97,7 @@ class EnvConfig:
     end: str = "2022-12-31"
     adjusted: bool = True
     eval_window_days: Optional[int] = None
+    custom_ranges: Optional[Sequence[Dict[str, Sequence[str]]]] = None
 
     fees: FeeModel = FeeModel()
     margin: MarginConfig = MarginConfig()
@@ -135,6 +136,7 @@ class EnvConfig:
             end=d.get("end", "2022-12-31"),
             adjusted=bool(d.get("adjusted", True)),
             eval_window_days=d.get("eval_window_days"),
+            custom_ranges=d.get("custom_ranges"),
 
             fees=mk(FeeModel, "fees"),
             margin=mk(MarginConfig, "margin"),

--- a/stockbot/rl/train_utils.py
+++ b/stockbot/rl/train_utils.py
@@ -15,6 +15,17 @@ def to_dt(s: str) -> datetime:
 
 def infer_split_from_cfg(cfg: EnvConfig) -> Split:
     """Train/eval split inference with optional eval window override."""
+    # Explicit custom ranges take precedence when provided
+    custom = getattr(cfg, "custom_ranges", None)
+    if custom:
+        try:
+            first = custom[0]
+            train = tuple(first["train"])  # type: ignore[index]
+            eval_ = tuple(first["eval"])   # type: ignore[index]
+            return Split(train=train, eval=eval_)
+        except Exception:
+            pass
+
     start = to_dt(cfg.start)
     end = to_dt(cfg.end)
 

--- a/stockbot/tests/test_train_utils.py
+++ b/stockbot/tests/test_train_utils.py
@@ -16,3 +16,20 @@ def test_custom_eval_window_overrides_default():
     assert split.eval == ("2024-02-01", "2024-02-10")
     assert split.train == ("2024-01-01", "2024-01-31")
 
+
+def test_custom_ranges_take_precedence():
+    cfg = EnvConfig(
+        symbols=["AAPL"],
+        interval="1d",
+        start="2024-01-01",
+        end="2024-12-31",
+        eval_window_days=10,
+        custom_ranges=[
+            {"train": ["2024-01-01", "2024-06-30"], "eval": ["2024-07-01", "2024-12-31"]}
+        ],
+        episode=EpisodeConfig(lookback=5),
+    )
+    split = infer_split_from_cfg(cfg)
+    assert split.train == ("2024-01-01", "2024-06-30")
+    assert split.eval == ("2024-07-01", "2024-12-31")
+


### PR DESCRIPTION
## Summary
- allow EnvConfig to carry optional custom train/eval ranges
- derive custom range from eval_window_days when requested through API
- prefer explicit custom ranges when computing train/eval splits
- strip deprecated nested groups when building config snapshots to avoid conflicting defaults

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c789fef2d8833196d3e3536a35e910