### PR TITLE
Add real-time validation feedback to StockBot training form

### DIFF
--- a/frontend/src/components/Stockbot/NewTraining/index.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/index.tsx
@@ -26,6 +26,377 @@ import { Label } from "@/components/ui/label";
 const TERMINAL: Array<JobStatusResponse["status"]> = ["SUCCEEDED", "FAILED", "CANCELLED"];
 const ppoDivisible = (n: number, b: number) => n > 0 && b > 0 && n % b === 0;
 
+type ValidationLevel = "error" | "warning" | "info";
+
+interface ValidationIssue {
+  level: ValidationLevel;
+  message: string;
+  detail?: string;
+  blocking?: boolean;
+}
+
+interface RangeSummary {
+  start: string;
+  end: string;
+  calendarDays: number;
+  businessDays: number;
+  bars: number;
+}
+
+interface ValidationResult {
+  issues: ValidationIssue[];
+  blockingIssues: ValidationIssue[];
+  split?: {
+    train: RangeSummary;
+    eval: RangeSummary;
+  };
+  requiredBars: number;
+}
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const BARS_PER_DAY: Record<"1d" | "1h" | "15m", number> = {
+  "1d": 1,
+  "1h": 6.5,
+  "15m": 26,
+};
+
+const formatIso = (d: Date) => d.toISOString().slice(0, 10);
+
+const parseIsoDate = (value: string | undefined | null): Date | null => {
+  if (!value || typeof value !== "string") return null;
+  const parts = value.split("-").map((x) => Number(x));
+  if (parts.length !== 3 || parts.some((x) => Number.isNaN(x))) return null;
+  const [y, m, day] = parts;
+  return new Date(Date.UTC(y, m - 1, day));
+};
+
+const addUtcDays = (d: Date, days: number) => {
+  const next = new Date(d.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+};
+
+const diffCalendarDays = (start: Date, end: Date) => {
+  if (end < start) return 0;
+  return Math.floor((end.getTime() - start.getTime()) / MS_PER_DAY);
+};
+
+const countBusinessDays = (start: Date, end: Date) => {
+  if (end < start) return 0;
+  let count = 0;
+  for (let d = new Date(start.getTime()); d.getTime() <= end.getTime(); d.setUTCDate(d.getUTCDate() + 1)) {
+    const day = d.getUTCDay();
+    if (day !== 0 && day !== 6) count += 1;
+  }
+  return count;
+};
+
+const summarizeRange = (start: Date, end: Date, interval: "1d" | "1h" | "15m"): RangeSummary => {
+  const calendarDays = diffCalendarDays(start, end) + 1; // inclusive span for display
+  const businessDays = countBusinessDays(start, end);
+  const multiplier = BARS_PER_DAY[interval] ?? 1;
+  const bars = Math.max(0, Math.round(businessDays * multiplier));
+  return {
+    start: formatIso(start),
+    end: formatIso(end),
+    calendarDays,
+    businessDays,
+    bars,
+  };
+};
+
+interface DeriveSplitInput {
+  start: Date;
+  end: Date;
+  interval: "1d" | "1h" | "15m";
+  lookback: number;
+  trainSplit: string;
+  evalWindow: number;
+}
+
+const deriveSplit = ({ start, end, lookback, trainSplit, evalWindow }: DeriveSplitInput) => {
+  const spanDays = diffCalendarDays(start, end);
+  let trainStart = new Date(start.getTime());
+  let trainEnd = new Date(end.getTime());
+  let evalStart = new Date(start.getTime());
+  let evalEnd = new Date(end.getTime());
+
+  const enforceMinEvalWindow = () => {
+    const minEvalDays = Math.max(100, Math.floor(lookback) + 40);
+    const evalSpan = diffCalendarDays(evalStart, evalEnd);
+    if (evalSpan < minEvalDays) {
+      let newEvalStart = addUtcDays(end, -minEvalDays);
+      if (newEvalStart < start) newEvalStart = new Date(start.getTime());
+      evalStart = newEvalStart;
+      const newTrainEnd = addUtcDays(evalStart, -1);
+      if (newTrainEnd >= start) {
+        trainEnd = newTrainEnd;
+      }
+    }
+  };
+
+  if (evalWindow && evalWindow > 0) {
+    evalEnd = new Date(end.getTime());
+    let candidate = addUtcDays(end, -(evalWindow - 1));
+    if (candidate < start) candidate = new Date(start.getTime());
+    evalStart = candidate;
+    const trainCandidate = addUtcDays(evalStart, -1);
+    trainStart = new Date(start.getTime());
+    trainEnd = trainCandidate >= start ? trainCandidate : new Date(start.getTime());
+    enforceMinEvalWindow();
+  } else if (trainSplit === "80_20" || spanDays < 365) {
+    const splitOffset = Math.floor(spanDays * 0.8);
+    const splitPoint = addUtcDays(start, splitOffset);
+    trainEnd = splitPoint >= start ? splitPoint : new Date(start.getTime());
+    evalStart = addUtcDays(trainEnd, 1);
+    evalEnd = new Date(end.getTime());
+    if (evalStart > evalEnd) {
+      evalStart = new Date(end.getTime());
+    }
+    enforceMinEvalWindow();
+  } else {
+    const lastYear = end.getUTCFullYear();
+    const janFirst = new Date(Date.UTC(lastYear, 0, 1));
+    if (start.getUTCFullYear() >= lastYear) {
+      const splitOffset = Math.floor(spanDays * 0.8);
+      const splitPoint = addUtcDays(start, splitOffset);
+      trainEnd = splitPoint >= start ? splitPoint : new Date(start.getTime());
+      evalStart = addUtcDays(trainEnd, 1);
+      evalEnd = new Date(end.getTime());
+    } else {
+      evalStart = janFirst < start ? new Date(start.getTime()) : janFirst;
+      evalEnd = new Date(end.getTime());
+      const candidateTrainEnd = addUtcDays(evalStart, -1);
+      trainEnd = candidateTrainEnd >= start ? candidateTrainEnd : new Date(start.getTime());
+    }
+    enforceMinEvalWindow();
+  }
+
+  if (trainEnd < trainStart) trainEnd = new Date(trainStart.getTime());
+  if (evalStart < start) evalStart = new Date(start.getTime());
+  if (evalEnd < evalStart) evalEnd = new Date(evalStart.getTime());
+
+  return {
+    train: { start: trainStart, end: trainEnd },
+    eval: { start: evalStart, end: evalEnd },
+  };
+};
+
+const computeValidation = (state: any): ValidationResult => {
+  const issues: ValidationIssue[] = [];
+  const symbols = String(state.symbols || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (symbols.length === 0) {
+    issues.push({
+      level: "error",
+      message: "Add at least one symbol to train on.",
+      blocking: true,
+    });
+  }
+
+  const interval = (state.interval as "1d" | "1h" | "15m") || "1d";
+  const startDate = parseIsoDate(state.start);
+  const endDate = parseIsoDate(state.end);
+  if (!startDate || !endDate) {
+    issues.push({
+      level: "error",
+      message: "Provide valid ISO dates for start and end (YYYY-MM-DD).",
+      blocking: true,
+    });
+    return {
+      issues,
+      blockingIssues: issues.filter((i) => i.level === "error" && i.blocking),
+      requiredBars: Math.max(0, Number(state.lookback) || 0) + 2,
+    };
+  }
+
+  if (endDate < startDate) {
+    issues.push({
+      level: "error",
+      message: "End date must be after start date.",
+      blocking: true,
+    });
+  }
+
+  const lookback = Number(state.lookback) || 0;
+  if (lookback <= 0) {
+    issues.push({
+      level: "error",
+      message: "Lookback must be a positive number of bars.",
+      blocking: true,
+    });
+  }
+
+  if (!Array.isArray(state.featureSet) || state.featureSet.length === 0) {
+    issues.push({
+      level: "error",
+      message: "Select at least one feature set.",
+      blocking: true,
+    });
+  }
+
+  const trainSplit = state.trainSplit || "last_year";
+  const evalWindow = Number(state.evalWindow) || 0;
+  let splitSummary: ValidationResult["split"] | undefined;
+
+  if (endDate >= startDate && lookback > 0) {
+    const split = deriveSplit({
+      start: startDate,
+      end: endDate,
+      lookback,
+      trainSplit,
+      evalWindow,
+      interval,
+    });
+    const trainRange = summarizeRange(split.train.start, split.train.end, interval);
+    const evalRange = summarizeRange(split.eval.start, split.eval.end, interval);
+    splitSummary = { train: trainRange, eval: evalRange };
+
+    const requiredBars = lookback + 2;
+    const warnThreshold = requiredBars + 10;
+
+    if (trainRange.bars < requiredBars) {
+      issues.push({
+        level: "error",
+        message: `Train window has ≈${trainRange.bars} bars but lookback requires at least ${requiredBars}.`,
+        detail: "Extend the training start date or lower the lookback.",
+        blocking: true,
+      });
+    } else if (trainRange.bars < warnThreshold) {
+      issues.push({
+        level: "warning",
+        message: `Train window is tight (≈${trainRange.bars} bars vs required ${requiredBars}).`,
+        detail: "Consider using a longer history for more stable training.",
+      });
+    }
+
+    if (evalRange.bars < requiredBars) {
+      issues.push({
+        level: "error",
+        message: `Eval window has ≈${evalRange.bars} bars but lookback requires at least ${requiredBars}.`,
+        detail: "Increase eval window days, extend the end date, or reduce lookback.",
+        blocking: true,
+      });
+    } else if (evalRange.bars < warnThreshold) {
+      issues.push({
+        level: "warning",
+        message: `Eval window is tight (≈${evalRange.bars} bars vs required ${requiredBars}).`,
+        detail: "Extend the evaluation window to avoid runtime errors.",
+      });
+    }
+
+    if (trainSplit === "custom_ranges") {
+      issues.push({
+        level: "info",
+        message: "Custom ranges selected — ensure payload JSON supplies explicit ranges (UI uses auto-split heuristics).",
+      });
+    }
+  }
+
+  const nSteps = Number(state.nSteps) || 0;
+  const batchSize = Number(state.batchSize) || 0;
+  if (!ppoDivisible(nSteps, batchSize)) {
+    issues.push({
+      level: "error",
+      message: "PPO expects batch_size to divide n_steps (per environment).",
+      detail: "Adjust n_steps or batch_size so n_steps % batch_size = 0.",
+      blocking: true,
+    });
+  }
+
+  if (state.volEnabled && Number(state.clampMin) === 0 && Number(state.clampMax) === 0) {
+    issues.push({
+      level: "error",
+      message: "Vol target clamps are 0/0 — exposure will pin near zero.",
+      detail: "Use wider clamps such as min 0.25 / max 2.0.",
+      blocking: true,
+    });
+  }
+
+  if (state.mappingMode === "tanh_leverage" && Number(state.grossLevCap) <= 1.0) {
+    issues.push({
+      level: "error",
+      message: "tanh_leverage mapping works best with gross_leverage_cap > 1.0.",
+      detail: "Increase the leverage cap or switch mapping modes.",
+      blocking: true,
+    });
+  }
+
+  const blockingIssues = issues.filter((i) => i.level === "error" && i.blocking);
+
+  return {
+    issues,
+    blockingIssues,
+    split: splitSummary,
+    requiredBars: Math.max(0, lookback) + 2,
+  };
+};
+
+const levelColors: Record<ValidationLevel, string> = {
+  error: "text-red-600 dark:text-red-400",
+  warning: "text-amber-600 dark:text-amber-400",
+  info: "text-sky-600 dark:text-sky-400",
+};
+
+const statusColor = (validation: ValidationResult) => {
+  if (validation.blockingIssues.length > 0) return "text-red-600 dark:text-red-400";
+  if (validation.issues.some((issue) => issue.level === "warning")) return "text-amber-600 dark:text-amber-400";
+  return "text-emerald-600 dark:text-emerald-400";
+};
+
+const statusLabel = (validation: ValidationResult) => {
+  if (validation.blockingIssues.length > 0) return "Fix blocking issues";
+  if (validation.issues.some((issue) => issue.level === "warning")) return "Review warnings";
+  return "Ready to train";
+};
+
+function ValidationSummaryCard({ validation }: { validation: ValidationResult }) {
+  return (
+    <div className="rounded-md border border-border/60 bg-muted/40 p-4 space-y-3">
+      <div className="flex items-center justify-between gap-2 text-sm">
+        <div className="font-medium text-foreground">Configuration checks</div>
+        <span className={`text-xs font-semibold uppercase tracking-wide ${statusColor(validation)}`}>
+          {statusLabel(validation)}
+        </span>
+      </div>
+      {validation.split && (
+        <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2">
+          <div>
+            <span className="font-semibold text-foreground">Train</span>: {validation.split.train.start} → {validation.split.train.end}
+            {" "}({validation.split.train.calendarDays} days, ≈{validation.split.train.bars} bars)
+          </div>
+          <div>
+            <span className="font-semibold text-foreground">Eval</span>: {validation.split.eval.start} → {validation.split.eval.end}
+            {" "}({validation.split.eval.calendarDays} days, ≈{validation.split.eval.bars} bars)
+          </div>
+          <div className="sm:col-span-2">
+            Minimum bars required by lookback: {validation.requiredBars}.
+          </div>
+        </div>
+      )}
+      <div className="space-y-2">
+        {validation.issues.length === 0 && (
+          <div className="text-xs text-muted-foreground">
+            No issues detected. You're good to start training.
+          </div>
+        )}
+        {validation.issues.map((issue, idx) => (
+          <div key={idx} className={`text-sm leading-snug ${levelColors[issue.level]}`}>
+            <div>
+              <span className="font-medium capitalize">{issue.level}:</span> {issue.message}
+            </div>
+            {issue.detail && <div className="text-xs text-muted-foreground">{issue.detail}</div>}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function NewTraining({
   onJobCreated,
   onCancel,
@@ -454,6 +825,8 @@ export default function NewTraining({
     ]
   );
 
+  const validation = useMemo(() => computeValidation(gatherState()), [gatherState]);
+
   const applyPayloadToState = (payload: TrainPayload) => {
     const toNumber = (value: unknown): number | undefined => {
       if (typeof value === "number") return value;
@@ -657,20 +1030,8 @@ export default function NewTraining({
     setJobId(null);
 
     // ---- Preflight guards ----
-    if (!ppoDivisible(nSteps, batchSize)) {
-      setError("PPO: batch_size should divide n_steps (or n_steps × n_envs).");
-      setSubmitting(false);
-      setProgress(null);
-      return;
-    }
-    if (volEnabled && clampMin === 0 && clampMax === 0) {
-      setError("Vol target clamps are 0/0 → exposure will pin near zero. Use e.g. min=0.25, max=2.0.");
-      setSubmitting(false);
-      setProgress(null);
-      return;
-    }
-    if (mappingMode === "tanh_leverage" && grossLevCap <= 1.0) {
-      setError("tanh_leverage requires gross_leverage_cap > 1.0 to be useful.");
+    if (validation.blockingIssues.length > 0) {
+      setError(validation.blockingIssues.map((issue) => issue.message).join(" "));
       setSubmitting(false);
       setProgress(null);
       return;
@@ -715,7 +1076,15 @@ export default function NewTraining({
           >
             Cancel
           </Button>
-          <Button onClick={onSubmit} disabled={submitting || isRunning}>
+          <Button
+            onClick={onSubmit}
+            disabled={submitting || isRunning || validation.blockingIssues.length > 0}
+            title={
+              validation.blockingIssues.length > 0
+                ? "Resolve configuration errors before starting"
+                : undefined
+            }
+          >
             {submitting && !status ? "Submitting…" : isRunning ? "Running…" : "Start Training"}
           </Button>
         </div>
@@ -739,6 +1108,8 @@ export default function NewTraining({
         </div>
       )}
       {error && <div className="text-sm text-red-600">{error}</div>}
+
+      <ValidationSummaryCard validation={validation} />
 
       <div className="space-y-2">
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- add client-side validation utilities to estimate train/eval coverage and flag configuration errors before submission
- render a configuration status card with warnings and prevent starting a run while blocking issues exist

## Testing
- npm run lint *(fails: `next` not found because dependencies could not be installed — `npm install` returns 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c8d3c4c7f4833199d60e1fe4c23c83