### PR TITLE
Refactor telemetry processing to worker and backend tail

### DIFF
--- a/frontend/src/components/Stockbot/RunMonitor.tsx
+++ b/frontend/src/components/Stockbot/RunMonitor.tsx
@@ -11,6 +11,12 @@ import api, { buildUrl } from "@/api/client";
 import { askJarvisLite, fetchAvailableModels } from "@/api/jarvisApi";
 import { formatPct, formatSigned } from "./lib/formats";
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, CartesianGrid, ReferenceLine, ReferenceDot, Tooltip } from "recharts";
+import type { TelemetryWorkerRequest, TelemetryWorkerResponse, TelemetryWorkerResult } from "@/workers/telemetryWorkerTypes";
+
+const MAX_LIVE_POINTS = 4000;
+const MAX_TERMINAL_POINTS = 4000;
+const MAX_LIVE_BARS = 4000;
+const TELEMETRY_TAIL_LIMIT = 4000;
 
 type TelemetryBar = any;
 type TelemetryEvent = any;
@@ -45,6 +51,10 @@ export default function RunMonitor({ runId }: { runId: string }) {
   const eventsFallbackRef = useRef<boolean>(false);
   const telemSeenRef = useRef<number>(0);
   const eventsSeenRef = useRef<number>(0);
+  const workerRef = useRef<Worker | null>(null);
+  const workerSeqRef = useRef<number>(0);
+  const workerAppliedSeqRef = useRef<number>(0);
+  const [seriesState, setSeriesState] = useState<TelemetryWorkerResult>({ pnl: [], expo: [], slip: [], tMin: 0, tMax: 1 });
   // Audit polling controls
   const auditTimerRef = useRef<any>(null);
   const auditAbortRef = useRef<AbortController | null>(null);
@@ -118,6 +128,33 @@ export default function RunMonitor({ runId }: { runId: string }) {
     const s = (runStatus?.status || '').toUpperCase();
     return s === 'RUNNING';
   })();
+
+  // Initialize telemetry processing worker once on the client
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (workerRef.current) return;
+    const worker = new Worker(new URL('../../workers/telemetryWorker.ts', import.meta.url));
+    workerRef.current = worker;
+    worker.onmessage = (event: MessageEvent<TelemetryWorkerResponse>) => {
+      const msg = event.data;
+      if (!msg || msg.type !== 'SERIES_READY') return;
+      if (msg.seq < workerAppliedSeqRef.current) return;
+      workerAppliedSeqRef.current = msg.seq;
+      const payload = msg.payload || { pnl: [], expo: [], slip: [], tMin: 0, tMax: 1 };
+      setSeriesState({
+        pnl: Array.isArray(payload.pnl) ? payload.pnl : [],
+        expo: Array.isArray(payload.expo) ? payload.expo : [],
+        slip: Array.isArray(payload.slip) ? payload.slip : [],
+        tMin: Number.isFinite(payload.tMin) ? payload.tMin : 0,
+        tMax: Number.isFinite(payload.tMax) ? payload.tMax : 1,
+      });
+    };
+    worker.onerror = () => {};
+    return () => {
+      try { worker.terminate(); } catch {}
+      workerRef.current = null;
+    };
+  }, []);
 
   // Connect SSE for bars (buffered; disabled when terminal)
   useEffect(() => {
@@ -194,7 +231,7 @@ export default function RunMonitor({ runId }: { runId: string }) {
             }
             const merged = fresh.length ? prev.concat(fresh) : prev;
             barsBufRef.current = [];
-            return merged.length > 2000 ? merged.slice(-1500) : merged;
+            return merged.length > MAX_LIVE_BARS ? merged.slice(-MAX_LIVE_BARS) : merged;
           });
           setLast(lastRef.current);
         }
@@ -219,19 +256,17 @@ export default function RunMonitor({ runId }: { runId: string }) {
     if (!isTerminal) return;
     (async () => {
       try {
-        // Load full telemetry history
-        const telemUrl = buildUrl(`/api/stockbot/runs/${runId}/files/live_telemetry`);
+        const telemUrl = buildUrl(`/api/stockbot/runs/${runId}/telemetry/tail?limit=${TELEMETRY_TAIL_LIMIT}`);
         const resp = await fetch(telemUrl, { credentials: 'include' });
         if (resp.ok) {
-          const txt = await resp.text();
-          const lines = parseJsonLines(txt);
-          const allBars: any[] = [];
-          for (const ln of lines) {
-            try { allBars.push(JSON.parse(ln)); } catch {}
-          }
-          if (allBars.length) {
-            setBars(allBars);
-            setLast(allBars[allBars.length - 1]);
+          const payload = await resp.json();
+          const items: any[] = Array.isArray(payload?.items) ? payload.items : [];
+          if (items.length) {
+            setBars(items);
+            const lastItem = items[items.length - 1] ?? null;
+            setLast(lastItem);
+            lastRef.current = lastItem;
+            barsBufRef.current = [];
           }
         }
       } catch {}
@@ -259,16 +294,27 @@ export default function RunMonitor({ runId }: { runId: string }) {
     const poll = async () => {
       try {
         if (telemFallbackRef.current && !isTerminal) {
-          const u = buildUrl(`/api/stockbot/runs/${runId}/files/live_telemetry`);
+          const u = buildUrl(`/api/stockbot/runs/${runId}/telemetry/tail?limit=${MAX_LIVE_BARS}`);
           const resp = await fetch(u, { credentials: 'include' });
           if (resp.ok) {
-            const txt = await resp.text();
-            const lines = parseJsonLines(txt);
-            const start = telemSeenRef.current;
-            for (let i = start; i < lines.length; i++) {
-              try { const j = JSON.parse(lines[i]); lastRef.current = j; barsBufRef.current.push(j); } catch {}
+            const payload = await resp.json();
+            const items: any[] = Array.isArray(payload?.items) ? payload.items : [];
+            const parseT = (t: any) => {
+              if (t == null) return NaN;
+              if (typeof t === 'number') return t;
+              const parsed = Date.parse(t);
+              if (!Number.isNaN(parsed)) return parsed;
+              const num = Number(t);
+              return Number.isNaN(num) ? NaN : num;
+            };
+            for (const item of items) {
+              const tt = parseT(item?.t);
+              if (!Number.isFinite(tt) || tt <= lastTSeenRef.current) continue;
+              lastRef.current = item;
+              barsBufRef.current.push(item);
+              lastTSeenRef.current = tt;
             }
-            telemSeenRef.current = lines.length;
+            telemSeenRef.current = items.length;
           }
         }
         if (eventsFallbackRef.current && !isTerminal) {
@@ -521,6 +567,30 @@ Data follows as labeled JSON/CSV snippets (trimmed).`;
     return cleanMonotonic(raw);
   }, [bars]);
 
+  useEffect(() => {
+    const worker = workerRef.current;
+    if (!worker) return;
+    const seq = workerSeqRef.current + 1;
+    workerSeqRef.current = seq;
+    const message: TelemetryWorkerRequest = {
+      type: 'PROCESS_SERIES',
+      seq,
+      payload: {
+        pnlSeries,
+        expoSeries,
+        slipSeries: slipTurnSeries,
+        isTerminal,
+        maxLivePoints: MAX_LIVE_POINTS,
+        maxTerminalPoints: MAX_TERMINAL_POINTS,
+      },
+    };
+    try {
+      worker.postMessage(message);
+    } catch (error) {
+      console.error('Failed to post telemetry payload to worker', error);
+    }
+  }, [pnlSeries, expoSeries, slipTurnSeries, isTerminal]);
+
   // Axis domains with padding
   const domainOf = (vals: number[], padFrac = 0.05, forceZeroTop = false): [number, number] => {
     let min = Infinity;
@@ -634,45 +704,13 @@ Data follows as labeled JSON/CSV snippets (trimmed).`;
       if (Number.isFinite(min) && Number.isFinite(max)) setToDomain(padDomain(min, max, 0.15));
     }
   }, [slipTurnSeries.length]);
-  // Use a shared time domain across all charts to ensure sync
-  const tMin = useMemo(() => {
-    let min = Infinity;
-    for (const d of pnlSeries) {
-      const v = Number(d?.t);
-      if (!Number.isFinite(v)) continue;
-      if (v < min) min = v;
-    }
-    for (const d of expoSeries) {
-      const v = Number(d?.t);
-      if (!Number.isFinite(v)) continue;
-      if (v < min) min = v;
-    }
-    for (const d of slipTurnSeries) {
-      const v = Number(d?.t);
-      if (!Number.isFinite(v)) continue;
-      if (v < min) min = v;
-    }
-    return Number.isFinite(min) ? min : 0;
-  }, [pnlSeries, expoSeries, slipTurnSeries]);
-  const tMax = useMemo(() => {
-    let max = -Infinity;
-    for (const d of pnlSeries) {
-      const v = Number(d?.t);
-      if (!Number.isFinite(v)) continue;
-      if (v > max) max = v;
-    }
-    for (const d of expoSeries) {
-      const v = Number(d?.t);
-      if (!Number.isFinite(v)) continue;
-      if (v > max) max = v;
-    }
-    for (const d of slipTurnSeries) {
-      const v = Number(d?.t);
-      if (!Number.isFinite(v)) continue;
-      if (v > max) max = v;
-    }
-    return Number.isFinite(max) ? max : 1;
-  }, [pnlSeries, expoSeries, slipTurnSeries]);
+  const safeTMin = Number.isFinite(seriesState.tMin) ? seriesState.tMin : 0;
+  const safeTMax = Number.isFinite(seriesState.tMax) ? seriesState.tMax : safeTMin + 1;
+  const tMin = safeTMin;
+  const tMax = safeTMax > safeTMin ? safeTMax : safeTMin + 1;
+  const pnlD = Array.isArray(seriesState.pnl) ? seriesState.pnl : [];
+  const expoD = Array.isArray(seriesState.expo) ? seriesState.expo : [];
+  const slipD = Array.isArray(seriesState.slip) ? seriesState.slip : [];
 
   const barsT = useMemo(() => bars.map((b) => parseTime(b?.t)), [bars]);
   const viewBar = useMemo(() => {
@@ -684,66 +722,6 @@ Data follows as labeled JSON/CSV snippets (trimmed).`;
     }
     return last;
   }, [viewIndex, bars, last, hoverTs, barsT]);
-  // Decimate series for readability (bumped density)
-  const decimate = <T,>(arr: T[], maxPoints = 3000): T[] => {
-    const n = arr.length; if (n <= maxPoints) return arr;
-    const step = Math.ceil(n / maxPoints); const out: T[] = [];
-    for (let i = 0; i < n; i += step) out.push(arr[i]);
-    if (out[out.length - 1] !== arr[n - 1]) out.push(arr[n - 1]);
-    return out;
-  };
-  // LTTB decimator for terminal (large) datasets
-  function lttb<T>(data: T[], threshold: number, getX: (p: T) => number, getY: (p: T) => number): T[] {
-    const n = data.length;
-    if (threshold >= n || threshold <= 2) return data.slice();
-    const sampled: T[] = [];
-    let a = 0;
-    sampled.push(data[a]);
-    const every = (n - 2) / (threshold - 2);
-    for (let i = 0; i < threshold - 2; i++) {
-      let avgX = 0, avgY = 0;
-      let avgRangeStart = Math.floor((i + 1) * every) + 1;
-      let avgRangeEnd = Math.floor((i + 2) * every) + 1;
-      if (avgRangeEnd > n) avgRangeEnd = n;
-      const avgRangeLength = Math.max(1, avgRangeEnd - avgRangeStart);
-      for (let idx = avgRangeStart; idx < avgRangeEnd; idx++) {
-        avgX += getX(data[idx]);
-        avgY += getY(data[idx]);
-      }
-      avgX /= avgRangeLength; avgY /= avgRangeLength;
-      let rangeOffs = Math.floor((i + 0) * every) + 1;
-      let rangeTo = Math.floor((i + 1) * every) + 1;
-      let maxArea = -1;
-      let nextA = rangeOffs;
-      let maxAreaPoint = data[rangeOffs] ?? data[a];
-      const ax = getX(data[a]);
-      const ay = getY(data[a]);
-      for (; rangeOffs < rangeTo && rangeOffs < n; rangeOffs++) {
-        const bx = getX(data[rangeOffs]);
-        const by = getY(data[rangeOffs]);
-        const area = Math.abs((ax - avgX) * (by - ay) - (ax - bx) * (avgY - ay)) * 0.5;
-        if (area > maxArea) { maxArea = area; maxAreaPoint = data[rangeOffs]; nextA = rangeOffs; }
-      }
-      sampled.push(maxAreaPoint);
-      a = nextA;
-    }
-    sampled.push(data[n - 1]);
-    return sampled;
-  }
-  const MAX_LIVE = 3000;      // live view (already trimmed upstream)
-  const MAX_TERMINAL = 4000;  // terminal view (full history)
-  const pnlD = useMemo(() => {
-    if (isTerminal) return pnlSeries.length > MAX_TERMINAL ? lttb(pnlSeries, MAX_TERMINAL, p => p.t, p => p.cum) : pnlSeries;
-    return decimate(pnlSeries, MAX_LIVE);
-  }, [pnlSeries, isTerminal]);
-  const expoD = useMemo(() => {
-    if (isTerminal) return expoSeries.length > MAX_TERMINAL ? lttb(expoSeries, MAX_TERMINAL, p => p.t, p => p.gross) : expoSeries;
-    return decimate(expoSeries, MAX_LIVE);
-  }, [expoSeries, isTerminal]);
-  const slipD = useMemo(() => {
-    if (isTerminal) return slipTurnSeries.length > MAX_TERMINAL ? lttb(slipTurnSeries, MAX_TERMINAL, p => p.t, p => p.slip) : slipTurnSeries;
-    return decimate(slipTurnSeries, MAX_LIVE);
-  }, [slipTurnSeries, isTerminal]);
   // Nearest point helpers for legends at hovered x
   function nearestIndex(arr: Array<{ t: number }>, t?: number): number {
     if (!arr.length) return -1;

--- a/frontend/src/workers/telemetryWorker.ts
+++ b/frontend/src/workers/telemetryWorker.ts
@@ -1,0 +1,135 @@
+/// <reference lib="webworker" />
+
+import type {
+  ExpoPoint,
+  PnlPoint,
+  SlipPoint,
+  TelemetryWorkerPayload,
+  TelemetryWorkerRequest,
+  TelemetryWorkerResponse,
+  TelemetryWorkerResult,
+} from "@/workers/telemetryWorkerTypes";
+
+const ctx: DedicatedWorkerGlobalScope = self as any;
+
+const fallbackDomain = { min: 0, max: 1 };
+
+function computeTimeDomain(series: Array<Array<{ t: number }>>): { min: number; max: number } {
+  let min = Infinity;
+  let max = -Infinity;
+  for (const arr of series) {
+    if (!Array.isArray(arr)) continue;
+    for (const p of arr) {
+      const t = Number((p as any)?.t);
+      if (!Number.isFinite(t)) continue;
+      if (t < min) min = t;
+      if (t > max) max = t;
+    }
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return fallbackDomain;
+  if (min === max) return { min, max: min + 1 };
+  return { min, max };
+}
+
+function decimate<T>(arr: T[], maxPoints: number): T[] {
+  const n = arr.length;
+  if (n <= maxPoints) return arr.slice();
+  const step = Math.ceil(n / maxPoints);
+  const out: T[] = [];
+  for (let i = 0; i < n; i += step) out.push(arr[i]);
+  if (out[out.length - 1] !== arr[n - 1]) out.push(arr[n - 1]);
+  return out;
+}
+
+function lttb<T>(data: T[], threshold: number, getX: (p: T) => number, getY: (p: T) => number): T[] {
+  const n = data.length;
+  if (threshold >= n || threshold <= 2) return data.slice();
+  const sampled: T[] = [];
+  let a = 0;
+  sampled.push(data[a]);
+  const every = (n - 2) / (threshold - 2);
+  for (let i = 0; i < threshold - 2; i++) {
+    let avgX = 0;
+    let avgY = 0;
+    let avgRangeStart = Math.floor((i + 1) * every) + 1;
+    let avgRangeEnd = Math.floor((i + 2) * every) + 1;
+    if (avgRangeEnd > n) avgRangeEnd = n;
+    const avgRangeLength = Math.max(1, avgRangeEnd - avgRangeStart);
+    for (let idx = avgRangeStart; idx < avgRangeEnd; idx++) {
+      avgX += getX(data[idx]);
+      avgY += getY(data[idx]);
+    }
+    avgX /= avgRangeLength;
+    avgY /= avgRangeLength;
+
+    let rangeOffs = Math.floor((i + 0) * every) + 1;
+    let rangeTo = Math.floor((i + 1) * every) + 1;
+    let maxArea = -1;
+    let nextA = rangeOffs;
+    let maxAreaPoint = data[rangeOffs] ?? data[a];
+    const ax = getX(data[a]);
+    const ay = getY(data[a]);
+    for (; rangeOffs < rangeTo && rangeOffs < n; rangeOffs++) {
+      const bx = getX(data[rangeOffs]);
+      const by = getY(data[rangeOffs]);
+      const area = Math.abs((ax - avgX) * (by - ay) - (ax - bx) * (avgY - ay)) * 0.5;
+      if (area > maxArea) {
+        maxArea = area;
+        maxAreaPoint = data[rangeOffs];
+        nextA = rangeOffs;
+      }
+    }
+    sampled.push(maxAreaPoint);
+    a = nextA;
+  }
+  sampled.push(data[n - 1]);
+  return sampled;
+}
+
+function downsampleSeries(series: PnlPoint[] | ExpoPoint[] | SlipPoint[], payload: TelemetryWorkerPayload): PnlPoint[] | ExpoPoint[] | SlipPoint[] {
+  const maxLive = Math.max(2, payload.maxLivePoints || 1);
+  const maxTerminal = Math.max(2, payload.maxTerminalPoints || 1);
+  if (payload.isTerminal) {
+    if (series.length > maxTerminal) {
+      if ((series[0] as any)?.cum !== undefined || (series[0] as any)?.dd !== undefined) {
+        return lttb(series, maxTerminal, (p: any) => Number(p.t) || 0, (p: any) => Number(p.cum ?? p.dd ?? 0));
+      }
+      if ((series[0] as any)?.gross !== undefined) {
+        return lttb(series, maxTerminal, (p: any) => Number(p.t) || 0, (p: any) => Number(p.gross ?? 0));
+      }
+      return lttb(series, maxTerminal, (p: any) => Number(p.t) || 0, (p: any) => Number(p.slip ?? p.to ?? 0));
+    }
+    return series.slice();
+  }
+  return decimate(series, maxLive);
+}
+
+function processPayload(payload: TelemetryWorkerPayload): TelemetryWorkerResult {
+  const pnl = downsampleSeries(payload.pnlSeries, payload) as PnlPoint[];
+  const expo = downsampleSeries(payload.expoSeries, payload) as ExpoPoint[];
+  const slip = downsampleSeries(payload.slipSeries, payload) as SlipPoint[];
+  const { min, max } = computeTimeDomain([payload.pnlSeries, payload.expoSeries, payload.slipSeries]);
+  return {
+    pnl,
+    expo,
+    slip,
+    tMin: Number.isFinite(min) ? min : fallbackDomain.min,
+    tMax: Number.isFinite(max) ? max : fallbackDomain.max,
+  };
+}
+
+ctx.onmessage = (event: MessageEvent<TelemetryWorkerRequest>) => {
+  const message = event.data;
+  if (!message || message.type !== "PROCESS_SERIES") return;
+  try {
+    const result = processPayload(message.payload);
+    const response: TelemetryWorkerResponse = {
+      type: "SERIES_READY",
+      seq: message.seq,
+      payload: result,
+    };
+    ctx.postMessage(response);
+  } catch (error) {
+    console.error("telemetryWorker failed to process payload", error);
+  }
+};

--- a/frontend/src/workers/telemetryWorkerTypes.ts
+++ b/frontend/src/workers/telemetryWorkerTypes.ts
@@ -1,0 +1,32 @@
+export type PnlPoint = { t: number; cum: number; dd: number };
+export type ExpoPoint = { t: number; gross: number };
+export type SlipPoint = { t: number; slip: number; to: number };
+
+export type TelemetryWorkerPayload = {
+  pnlSeries: PnlPoint[];
+  expoSeries: ExpoPoint[];
+  slipSeries: SlipPoint[];
+  isTerminal: boolean;
+  maxLivePoints: number;
+  maxTerminalPoints: number;
+};
+
+export type TelemetryWorkerRequest = {
+  type: "PROCESS_SERIES";
+  seq: number;
+  payload: TelemetryWorkerPayload;
+};
+
+export type TelemetryWorkerResult = {
+  pnl: PnlPoint[];
+  expo: ExpoPoint[];
+  slip: SlipPoint[];
+  tMin: number;
+  tMax: number;
+};
+
+export type TelemetryWorkerResponse = {
+  type: "SERIES_READY";
+  seq: number;
+  payload: TelemetryWorkerResult;
+};

--- a/stockbot/api/controllers/stockbot_controller.py
+++ b/stockbot/api/controllers/stockbot_controller.py
@@ -9,6 +9,7 @@ from tempfile import NamedTemporaryFile
 from pathlib import Path
 from datetime import datetime
 from typing import Any, List, Optional, Dict, Literal
+from collections import deque
 import secrets
 import yaml
 import shutil
@@ -805,6 +806,49 @@ SAFE_NAME_MAP = {
     "live_rollups": "live_rollups.jsonl",
     "live_audit": "live_audit.jsonl",
 }
+
+def get_telemetry_tail(run_id: str, limit: int = 4000):
+    r = RUN_MANAGER.get(run_id)
+    try:
+        limit = int(limit)
+    except Exception:
+        limit = 4000
+    if limit <= 0:
+        limit = 1
+    limit = min(limit, 10000)
+
+    rel = SAFE_NAME_MAP.get("live_telemetry")
+    if not rel:
+        raise HTTPException(status_code=404, detail="Telemetry mapping missing")
+
+    path = Path(r.out_dir) / rel
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Telemetry file not found")
+
+    total = 0
+    buf: deque[Any] = deque(maxlen=limit)
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                total += 1
+                try:
+                    obj = json.loads(stripped)
+                except Exception:
+                    obj = {"raw": stripped}
+                buf.append(obj)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to read telemetry: {e}")
+
+    items = list(buf)
+    return JSONResponse({
+        "items": items,
+        "returned": len(items),
+        "total": total,
+        "has_more": total > len(items),
+    })
 
 def get_artifact_file(run_id: str, name: str):
     r = RUN_MANAGER.get(run_id)

--- a/stockbot/api/routes/stockbot_routes.py
+++ b/stockbot/api/routes/stockbot_routes.py
@@ -25,6 +25,7 @@ from api.controllers.stockbot_controller import (
     bundle_zip,
     cancel_run,
     delete_run,
+    get_telemetry_tail,
 )
 from api.controllers.insights_controller import InsightsRequest, generate_insights
 from api.controllers.highlights_controller import HighlightsRequest, generate_highlights
@@ -89,6 +90,11 @@ def get_run_artifacts(run_id: str):
 @router.get("/runs/{run_id}/files/{name}")
 def get_run_artifact_file(run_id: str, name: str):
     return get_artifact_file(run_id, name)
+
+
+@router.get("/runs/{run_id}/telemetry/tail")
+def get_run_telemetry_tail(run_id: str, limit: int = 4000):
+    return get_telemetry_tail(run_id, limit=limit)
 
 
 @router.get("/runs/{run_id}/bundle")


### PR DESCRIPTION
## Summary
- add a backend telemetry tail endpoint that returns a JSON payload capped to the requested limit
- stream telemetry through a dedicated web worker so down-sampling and domain scans no longer block the UI thread
- limit the frontend monitor to tail-fetching <=4k points and reuse the worker results for chart domains and legends

## Testing
- `npm run lint` *(fails: next not found because dependencies are not installed in the execution environment)*
- `npm install` *(fails: npm registry responded 403 Forbidden while fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c98e0ee1708331b48ff1b29dc8fcce