### PR TITLE
Handle telemetry tail absence gracefully and fix monitor wheel listener

### DIFF
--- a/backend/controllers/stockbotController.js
+++ b/backend/controllers/stockbotController.js
@@ -183,7 +183,12 @@ export async function getRunTelemetryTailProxy(req, res) {
       if (!rel) throw new Error("live telemetry mapping missing");
       const abs = path.join(RUNS_DIR, String(req.params.id), rel);
       if (!fs.existsSync(abs)) {
-        return res.status(404).json({ error: "Telemetry file not found" });
+        return res.json({
+          items: [],
+          returned: 0,
+          total: 0,
+          has_more: false,
+        });
       }
       const text = await fs.promises.readFile(abs, "utf-8");
       const lines = text

--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -546,15 +546,21 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
     return () => { if (raf != null) cancelAnimationFrame(raf); };
   }, [monitorOpen, monitorHover]);
 
-  const onMonitorWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+  useEffect(() => {
     const el = monitorRef.current;
     if (!el) return;
-    // Always consume the wheel so the page doesn't scroll
-    e.preventDefault();
-    e.stopPropagation();
-    userScrollRef.current = Date.now();
-    el.scrollTop += e.deltaY;
-  };
+    const handleWheel = (event: WheelEvent) => {
+      // Always consume the wheel so the page doesn't scroll the document
+      event.preventDefault();
+      event.stopPropagation();
+      userScrollRef.current = Date.now();
+      el.scrollTop += event.deltaY;
+    };
+    el.addEventListener("wheel", handleWheel, { passive: false });
+    return () => {
+      el.removeEventListener("wheel", handleWheel);
+    };
+  }, [monitorOpen]);
 
   const onMonitorPointer = () => {
     userInteractRef.current = Date.now();
@@ -1323,7 +1329,6 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
             onMouseLeave={() => setMonitorHover(false)}
             onMouseMoveCapture={onMonitorPointer}
             onPointerDownCapture={onMonitorPointer}
-            onWheelCapture={onMonitorWheel}
             data-lenis-prevent
             data-lenis-prevent-wheel
             data-lenis-prevent-touch


### PR DESCRIPTION
## Summary
- return an empty telemetry payload instead of a 404 when no live telemetry file is present
- attach a non-passive wheel listener to the monitor drawer so preventDefault works and drop the JSX handler

## Testing
- npm run lint *(fails: next not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c99d363648833181b6234e1702dadf