### PR TITLE
Implement chunked telemetry streaming

### DIFF
--- a/backend/controllers/stockbotController.js
+++ b/backend/controllers/stockbotController.js
@@ -514,6 +514,35 @@ export async function getRunTelemetryTailProxy(req, res) {
   }
 }
 
+export async function getRunTelemetryChunkProxy(req, res) {
+  const rawLimit = Array.isArray(req.query?.limit) ? req.query.limit[0] : req.query?.limit;
+  let limit = Number.parseInt(rawLimit ?? "", 10);
+  if (!Number.isFinite(limit)) limit = 1000;
+  if (limit <= 0) limit = 1;
+  if (limit > 5000) limit = 5000;
+
+  const params = { limit };
+  const rawCursor = Array.isArray(req.query?.cursor) ? req.query.cursor[0] : req.query?.cursor;
+  if (typeof rawCursor === "string" && rawCursor.length > 0) {
+    params.cursor = rawCursor;
+  }
+
+  try {
+    const { data } = await stockbotRequest({
+      method: "get",
+      url: `/api/stockbot/runs/${encodeURIComponent(req.params.id)}/telemetry/chunk`,
+      params,
+    }, { retries: 2 });
+    return res.json(data);
+  } catch (e) {
+    if (axios.isAxiosError(e)) {
+      const { status, body } = safeErrorBody(e, e.response?.status ?? 502);
+      return res.status(status).json(body);
+    }
+    return res.status(500).json({ error: errMsg(e) });
+  }
+}
+
 /** GET /api/stockbot/runs/:id/files/:name -> stream file */
 export async function getRunArtifactFileProxy(req, res) {
   try {

--- a/backend/routes/stockbotRoutes.js
+++ b/backend/routes/stockbotRoutes.js
@@ -13,6 +13,7 @@ import {
   getRunArtifactFileProxy,
   getRunBundleProxy,
   getRunTelemetryTailProxy,
+  getRunTelemetryChunkProxy,
   streamRunTelemetryProxy,
   streamRunEventsProxy,
   streamRunStatusProxy,
@@ -51,6 +52,7 @@ router.get("/runs/:id", protectRoute, getRunProxy);
 router.delete("/runs/:id", protectRoute, deleteRunProxy);
 router.get("/runs/:id/artifacts", protectRoute, getRunArtifactsProxy);
 router.get("/runs/:id/telemetry/tail", protectRoute, getRunTelemetryTailProxy);
+router.get("/runs/:id/telemetry/chunk", protectRoute, getRunTelemetryChunkProxy);
 router.get("/runs/:id/telemetry", protectRoute, streamRunTelemetryProxy);
 router.get("/runs/:id/events", protectRoute, streamRunEventsProxy);
 

--- a/frontend/src/components/Stockbot/RunMonitor.tsx
+++ b/frontend/src/components/Stockbot/RunMonitor.tsx
@@ -20,25 +20,11 @@ const MAX_LIVE_POINTS = 4000;
 const MAX_TERMINAL_POINTS = 4000;
 const MAX_LIVE_BARS = 4000;
 const MAX_SNAPSHOT_LINES = 8000;
-const MAX_SNAPSHOT_BYTES = 5 * 1024 * 1024; // 5 MB safety cap
 
 type TelemetryBar = any;
 type TelemetryEvent = any;
 type TelemetryTailMeta = { total: number | null; returned: number; hasMore: boolean };
 type TelemetryNotice = { message: string; severity: "info" | "warning" };
-
-function formatBytes(value: number): string {
-  if (!Number.isFinite(value) || value <= 0) return "unknown size";
-  const units = ["B", "KB", "MB", "GB"];
-  let idx = 0;
-  let current = value;
-  while (current >= 1024 && idx < units.length - 1) {
-    current /= 1024;
-    idx += 1;
-  }
-  const precision = current >= 10 || idx === 0 ? 0 : 1;
-  return `${current.toFixed(precision)} ${units[idx]}`;
-}
 
 const pnlChartConfig: ChartConfig = {
   cum: { label: "Cum P&L (%)", color: "#2563eb" },
@@ -356,52 +342,72 @@ export default function RunMonitor({ runId }: { runId: string }) {
       fullSnapshotLoadingRef.current = true;
       setFullSnapshotLoading(true);
       try {
-        const url = buildUrl(`/api/stockbot/runs/${runId}/files/live_telemetry`);
-        const resp = await fetch(url, { credentials: 'include' });
-        if (!resp.ok) {
+        const aggregated: TelemetryBar[] = [];
+        let cursor: number | null = 0;
+        let hasMore = false;
+        let guard = 0;
+        while (cursor !== null && aggregated.length < MAX_SNAPSHOT_LINES && guard < 100) {
+          const remaining = MAX_SNAPSHOT_LINES - aggregated.length;
+          const limit = Math.min(remaining, 1000);
+          const params = new URLSearchParams({ limit: String(limit) });
+          if (cursor > 0) params.set('cursor', String(cursor));
+          const chunkUrl = buildUrl(`/api/stockbot/runs/${runId}/telemetry/chunk?${params.toString()}`);
+          const resp = await fetch(chunkUrl, { credentials: 'include' });
+          if (!resp.ok) {
+            throw new Error(`chunk ${resp.status}`);
+          }
+          const payload = await resp.json();
+          const items: TelemetryBar[] = Array.isArray(payload?.items) ? payload.items : [];
+          if (items.length > 0) {
+            aggregated.push(...items);
+          }
+          const nextCursorRaw = payload?.next_cursor;
+          const nextCursor = Number.isFinite(Number(nextCursorRaw)) ? Number(nextCursorRaw) : null;
+          hasMore = Boolean(payload?.has_more);
+          if (!hasMore || nextCursor === null || nextCursor === cursor) {
+            cursor = null;
+          } else {
+            cursor = nextCursor;
+          }
+          if (!items.length && !hasMore) {
+            break;
+          }
+          guard += 1;
+        }
+
+        if (!aggregated.length) {
           setTelemetryNotice({
             severity: 'warning',
-            message: `Failed to load full telemetry snapshot (${resp.status}).`,
+            message: 'No telemetry history is available for this run.',
           });
+          const emptyMeta: TelemetryTailMeta = { total: 0, returned: 0, hasMore: false };
+          lastTailMetaRef.current = emptyMeta;
+          setTelemetryTailMeta(emptyMeta);
+          fullSnapshotLoadedRef.current = true;
           return;
         }
-        const contentLengthHeader = resp.headers.get('content-length');
-        const contentLength = contentLengthHeader ? Number.parseInt(contentLengthHeader, 10) : NaN;
-        const tooManyLines = totalHint != null && totalHint > MAX_SNAPSHOT_LINES;
-        const tooLarge = Number.isFinite(contentLength) && contentLength > MAX_SNAPSHOT_BYTES;
-        if (tooManyLines || tooLarge) {
-          const parts: string[] = [];
-          if (tooManyLines && totalHint != null) parts.push(`${totalHint.toLocaleString()} bars`);
-          if (tooLarge) parts.push(`${formatBytes(contentLength)} snapshot`);
-          const reason = parts.length ? parts.join(' / ') : 'size';
-          const prefix = opts?.manual ? 'Unable to load full telemetry snapshot' : 'Skipped loading full telemetry snapshot';
-          setTelemetryNotice({
-            severity: 'warning',
-            message: `${prefix} because it exceeds the safe limit (${reason}). Download the raw live_telemetry.jsonl file instead.`,
-          });
-          try { await resp.body?.cancel?.(); } catch {}
-          return;
-        }
-        const txt = await resp.text();
-        const lines = parseJsonLines(txt);
-        const parsed: TelemetryBar[] = [];
-        for (const ln of lines) {
-          try {
-            parsed.push(JSON.parse(ln));
-          } catch {}
-        }
-        const outcome = appendTelemetryBars(parsed, true);
+
+        const outcome = appendTelemetryBars(aggregated, true);
         applyAppendOutcome(outcome);
-        const total = parsed.length;
-        lastTailMetaRef.current = { total, returned: total, hasMore: false };
-        setTelemetryTailMeta({ total, returned: total, hasMore: false });
+        const total = aggregated.length;
+        const truncated = hasMore || total >= MAX_SNAPSHOT_LINES;
+        const meta: TelemetryTailMeta = { total, returned: total, hasMore: truncated };
+        lastTailMetaRef.current = meta;
+        setTelemetryTailMeta(meta);
         fullSnapshotLoadedRef.current = true;
-        setTelemetryNotice(null);
+        setTelemetryNotice(
+          truncated
+            ? {
+                severity: 'warning',
+                message: `Loaded ${total.toLocaleString()} telemetry bars. History is truncated; download the raw live_telemetry.jsonl file for the full dataset.`,
+              }
+            : null
+        );
       } catch (error) {
-        console.error('Failed to load full telemetry snapshot', error);
+        console.error('Failed to load telemetry history', error);
         setTelemetryNotice({
           severity: 'warning',
-          message: 'Failed to load full telemetry snapshot.',
+          message: 'Failed to load telemetry history.',
         });
       } finally {
         fullSnapshotLoadingRef.current = false;
@@ -1153,7 +1159,7 @@ Data follows as labeled JSON/CSV snippets (trimmed).`;
                 disabled={fullSnapshotLoading || exceedsLineLimit}
                 onClick={() => requestFullTelemetrySnapshot({ force: true, totalHint: totalEstimate ?? undefined, manual: true })}
               >
-                {fullSnapshotLoading ? 'Loading…' : 'Load full history'}
+                {fullSnapshotLoading ? 'Loading…' : 'Load history snapshot'}
               </Button>
               {exceedsLineLimit && (
                 <span className="text-xs text-muted-foreground">

--- a/stockbot/api/controllers/stockbot_controller.py
+++ b/stockbot/api/controllers/stockbot_controller.py
@@ -16,7 +16,7 @@ import shutil
 import json
 
 from fastapi import BackgroundTasks, HTTPException, UploadFile, File
-from fastapi.responses import JSONResponse, FileResponse, PlainTextResponse
+from fastapi.responses import JSONResponse, FileResponse, StreamingResponse
 from fastapi import Request
 from pydantic import BaseModel, Field
 
@@ -48,6 +48,20 @@ def _resolve_under_project(path: str | Path) -> Path:
     if not p.is_absolute():
         p = (PROJECT_ROOT / p).resolve()
     return p
+
+
+def _iter_file_bytes(path: Path, chunk_size: int = 1024 * 1024):
+    """Yield chunks from *path* without loading the whole file into memory."""
+
+    def _gen():
+        with path.open("rb") as fh:
+            while True:
+                chunk = fh.read(chunk_size)
+                if not chunk:
+                    break
+                yield chunk
+
+    return _gen()
 
 # Allow-list server-write roots (optional but recommended)
 ALLOWED_OUTPUT_ROOTS: List[Path] = [RUNS_DIR]
@@ -850,6 +864,89 @@ def get_telemetry_tail(run_id: str, limit: int = 4000):
         "has_more": total > len(items),
     })
 
+
+def get_telemetry_chunk(run_id: str, cursor: int | None = None, limit: int = 1000):
+    r = RUN_MANAGER.get(run_id)
+    rel = SAFE_NAME_MAP.get("live_telemetry")
+    if not rel:
+        raise HTTPException(status_code=404, detail="Telemetry mapping missing")
+
+    path = Path(r.out_dir) / rel
+    if not path.exists():
+        raise HTTPException(status_code=404, detail="Telemetry file not found")
+
+    try:
+        limit = int(limit)
+    except Exception:
+        limit = 1000
+    if limit <= 0:
+        limit = 1
+    limit = min(limit, 5000)
+
+    try:
+        file_size = path.stat().st_size
+    except Exception:
+        file_size = None
+
+    cursor_val = 0
+    if cursor is not None:
+        try:
+            cursor_val = int(cursor)
+        except Exception:
+            cursor_val = 0
+    if file_size is not None and cursor_val > file_size:
+        cursor_val = file_size
+    if cursor_val < 0:
+        if file_size is not None:
+            cursor_val = max(file_size + cursor_val, 0)
+        else:
+            cursor_val = 0
+
+    items: list[Any] = []
+    start_cursor = 0
+    next_cursor = cursor_val
+    eof_reached = False
+
+    try:
+        with path.open("r", encoding="utf-8", errors="ignore") as fh:
+            if cursor_val > 0:
+                try:
+                    fh.seek(cursor_val)
+                except OSError:
+                    fh.seek(0)
+                # Align to the next full line to avoid returning partial JSON
+                fh.readline()
+            start_cursor = fh.tell()
+            while len(items) < limit:
+                line = fh.readline()
+                if not line:
+                    eof_reached = True
+                    break
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    obj = json.loads(stripped)
+                except Exception:
+                    obj = {"raw": stripped}
+                items.append(obj)
+            next_cursor = fh.tell()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"Failed to read telemetry chunk: {exc}")
+
+    has_more = not eof_reached and len(items) >= limit
+    if not has_more and file_size is not None and next_cursor < file_size:
+        has_more = True
+
+    payload = {
+        "items": items,
+        "cursor": start_cursor,
+        "next_cursor": next_cursor,
+        "has_more": has_more,
+        "file_size": file_size,
+    }
+    return JSONResponse(payload)
+
 def get_artifact_file(run_id: str, name: str):
     r = RUN_MANAGER.get(run_id)
     rel = SAFE_NAME_MAP.get(name)
@@ -864,12 +961,11 @@ def get_artifact_file(run_id: str, name: str):
     LIVE_TEXT_NAMES = {"live_telemetry", "live_events", "live_rollups", "live_audit", "job_log"}
     if name in LIVE_TEXT_NAMES:
         try:
-            # Read a snapshot at request time; clients poll and diff/tail as needed
-            txt = path.read_text(encoding="utf-8", errors="ignore")
-        except Exception:
-            txt = ""
-        # NDJSON / log text — serve as plain text to avoid strict JSON parsing at proxies
-        return PlainTextResponse(txt)
+            iterator = _iter_file_bytes(path)
+        except Exception as exc:
+            raise HTTPException(status_code=500, detail=f"Failed to stream file: {exc}")
+        # NDJSON / log text — stream as plain text so callers can incrementally consume it
+        return StreamingResponse(iterator, media_type="text/plain; charset=utf-8")
     return FileResponse(str(path), filename=path.name)
 
 # Cancel a running job by pid

--- a/stockbot/api/routes/stockbot_routes.py
+++ b/stockbot/api/routes/stockbot_routes.py
@@ -26,6 +26,7 @@ from api.controllers.stockbot_controller import (
     cancel_run,
     delete_run,
     get_telemetry_tail,
+    get_telemetry_chunk,
 )
 from api.controllers.insights_controller import InsightsRequest, generate_insights
 from api.controllers.highlights_controller import HighlightsRequest, generate_highlights
@@ -95,6 +96,11 @@ def get_run_artifact_file(run_id: str, name: str):
 @router.get("/runs/{run_id}/telemetry/tail")
 def get_run_telemetry_tail(run_id: str, limit: int = 4000):
     return get_telemetry_tail(run_id, limit=limit)
+
+
+@router.get("/runs/{run_id}/telemetry/chunk")
+def get_run_telemetry_chunk(run_id: str, cursor: int | None = None, limit: int = 1000):
+    return get_telemetry_chunk(run_id, cursor=cursor, limit=limit)
 
 
 @router.get("/runs/{run_id}/bundle")


### PR DESCRIPTION
## Summary
- stream live telemetry, events, and logs from FastAPI without loading entire files into memory
- add a chunked telemetry endpoint plus Node proxy routing so clients can page through history safely
- update the RunMonitor UI to request paginated telemetry snapshots and adjust messaging

## Testing
- npm install *(fails: 403 Forbidden when fetching packages)*
- npm run lint *(fails: `next` binary missing because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cae1eeb6208331b812b5aa1fa7b68d