### PR TITLE
Fix turnover percentage display in state snapshot

### DIFF
--- a/frontend/src/components/Stockbot/RunMonitor.tsx
+++ b/frontend/src/components/Stockbot/RunMonitor.tsx
@@ -1400,7 +1400,7 @@ export default function RunMonitor({ runId }: { runId: string }) {
             </div>
             <div>
               <span className="uppercase">Turnover</span>
-              <div className="font-mono text-sm">{formatPct((selectedHistorical?.slip?.to ?? 0) / 100)}</div>
+              <div className="font-mono text-sm">{formatPct(selectedHistorical?.slip?.to ?? 0)}</div>
             </div>
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- ensure the run monitor state snapshot displays turnover using the reported fractional value so percentages are correct

## Testing
- npm --prefix frontend ci *(fails: 403 Forbidden retrieving react package)*

------
https://chatgpt.com/codex/tasks/task_e_68cb504bd7b0833180fda51ed8272d4e