### PR TITLE
Fix rolling metrics fetch in run monitor

### DIFF
--- a/frontend/src/components/Stockbot/RunMonitor.tsx
+++ b/frontend/src/components/Stockbot/RunMonitor.tsx
@@ -725,13 +725,10 @@ export default function RunMonitor({ runId }: { runId: string }) {
     let cancelled = false;
     const hasKey = Object.prototype.hasOwnProperty.call(artifacts, "rolling_metrics");
     const path = (artifacts as Record<string, string | null>)?.rolling_metrics ?? null;
-    if (hasKey && !path) {
+    const expectMissing = hasKey && !path;
+    if (expectMissing) {
       setRolling([]);
       setRollingError(null);
-      setRollingLoading(false);
-      return () => {
-        cancelled = true;
-      };
     }
     const url = buildUrl(path || `/api/stockbot/runs/${runId}/files/rolling_metrics`);
     setRollingLoading(true);
@@ -760,7 +757,11 @@ export default function RunMonitor({ runId }: { runId: string }) {
         if (!cancelled) {
           const msg = err?.message || "Failed to load rolling metrics";
           setRolling([]);
-          setRollingError(msg.includes("404") ? null : msg);
+          if (expectMissing || msg.includes("404")) {
+            setRollingError(null);
+          } else {
+            setRollingError(msg);
+          }
         }
       } finally {
         if (!cancelled) setRollingLoading(false);


### PR DESCRIPTION
## Summary
- ensure the run monitor still requests rolling metrics data when the artifact path is missing so backend fallbacks can run
- clear rolling metrics state while waiting and keep 404s silent when we expect the artifact to be absent

## Testing
- `npm run lint` *(fails: Next.js binary is unavailable before dependencies can be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3c6235ac833184c253256a8092de