### PR TITLE
Fix dock layout updates and tab markup

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -220,6 +220,9 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   const [timeRange, setTimeRange] = useState<[number, number] | null>(null);
   const dockApiRef = useRef<DockviewApi | null>(null);
   const suppressLayoutChangeRef = useRef(false);
+  const pendingLayoutChangeRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const [dockReady, setDockReady] = useState(false);
   const [currentLayout, setCurrentLayout] = useState<string>("default");
   const [hasSavedLayout, setHasSavedLayout] = useState(false);
@@ -894,6 +897,15 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
     setHasSavedLayout(Boolean(localStorage.getItem(TRAINING_LAYOUT_STORAGE_KEY)));
   }, []);
 
+  useEffect(() => {
+    return () => {
+      if (pendingLayoutChangeRef.current) {
+        clearTimeout(pendingLayoutChangeRef.current);
+        pendingLayoutChangeRef.current = null;
+      }
+    };
+  }, []);
+
   const applyLayout = useCallback(
     (layout: DockviewLayout, presetId?: string) => {
       const api = dockApiRef.current;
@@ -944,7 +956,13 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
 
   const handleLayoutChange = useCallback(() => {
     if (suppressLayoutChangeRef.current) return;
-    setCurrentLayout("custom");
+    if (pendingLayoutChangeRef.current) {
+      clearTimeout(pendingLayoutChangeRef.current);
+    }
+    pendingLayoutChangeRef.current = setTimeout(() => {
+      pendingLayoutChangeRef.current = null;
+      setCurrentLayout("custom");
+    }, 0);
   }, []);
 
   const handlePresetChange = useCallback(

--- a/frontend/src/lib/dockview/index.tsx
+++ b/frontend/src/lib/dockview/index.tsx
@@ -400,13 +400,22 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
                   const api = ensurePanelApi(tab);
                   const isActive = tab.id === activeId;
                   return (
-                    <button
+                    <div
                       key={tab.id}
+                      role="tab"
+                      aria-selected={isActive}
+                      tabIndex={0}
                       className={["dv-tab", isActive ? "dv-tab-active" : ""].join(" ").trim()}
                       draggable
                       onDragStart={() => handleDragStart(tab.id)}
                       onDragEnd={handleDragEnd}
                       onClick={() => focusPanelInternal(tab.id)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          focusPanelInternal(tab.id);
+                        }
+                      }}
                       onDragOver={(e) => {
                         if (!draggingIdRef.current || draggingIdRef.current === tab.id) return;
                         e.preventDefault();
@@ -419,7 +428,7 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
                         handleGroupDrop(groupIndex, tabIndex);
                       }}
                     >
-                      <span>{tab.title}</span>
+                      <span className="dv-tab-title">{tab.title}</span>
                       <button
                         type="button"
                         className="dv-tab-close"
@@ -430,7 +439,7 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
                       >
                         ×
                       </button>
-                    </button>
+                    </div>
                   );
                 })}
               </div>


### PR DESCRIPTION
## Summary
- defer layout change state updates in TrainingResults to avoid setState during Dockview render
- add cleanup for pending layout change timers when TrainingResults unmounts
- replace nested button markup in dock tab rendering with a div wrapper and keyboard handler to satisfy HTML semantics

## Testing
- npm run lint *(fails: next binary unavailable before installing dependencies)*
- npm install *(fails: npm registry responded with HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd17dd4208331be297b48798c2819