### PR TITLE
Improve dockview panel management

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -99,6 +99,9 @@ const cloneDockLayout = (layout: DockviewLayout): DockviewLayout => ({
   })),
 });
 
+const extractPanelIds = (layout: DockviewLayout): string[] =>
+  layout.groups.flatMap((group) => group.tabs.map((tab) => tab.id));
+
 const createPanel = <K extends keyof typeof panelDefinitions>(key: K) => ({
   ...panelDefinitions[key],
 });
@@ -186,6 +189,8 @@ const DOCK_PRESETS: Array<{ id: string; label: string; layout: DockviewLayout }>
   { id: "compact", label: "Compact Stack", layout: compactDockLayout },
 ];
 
+type PanelKey = keyof typeof panelDefinitions;
+
 export default function TrainingResults({ initialRunId }: { initialRunId?: string }) {
   const [runs, setRuns] = useState<RunSummary[]>([]);
   const [runId, setRunId] = useState<string>(initialRunId || "");
@@ -198,6 +203,7 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   const [equity, setEquity] = useState<Array<{ step: number; equity: number }>>([]);
   const [drawdown, setDrawdown] = useState<Array<{ step: number; dd: number }>>([]);
   const [lev, setLev] = useState<Array<{ step: number; to: number; gl: number; nl: number }>>([]);
+  const [openPanels, setOpenPanels] = useState<string[]>([]);
   const [artifacts, setArtifacts] = useState<RunArtifacts | null>(null);
   const [showHeatmap, setShowHeatmap] = useState(false);
   const [showCharts, setShowCharts] = useState(false);
@@ -912,35 +918,37 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
       if (!api) return;
       suppressLayoutChangeRef.current = true;
       api.fromJSON(cloneDockLayout(layout));
+      setOpenPanels(extractPanelIds(layout));
       setCurrentLayout(presetId ?? "custom");
       setTimeout(() => {
         suppressLayoutChangeRef.current = false;
       }, 0);
     },
-    []
+    [setOpenPanels]
   );
 
-  const loadSavedLayout = useCallback(() => {
-    if (typeof window === "undefined") return false;
+  const loadSavedLayout = useCallback((): DockviewLayout | null => {
+    if (typeof window === "undefined") return null;
     const api = dockApiRef.current;
-    if (!api) return false;
+    if (!api) return null;
     const raw = localStorage.getItem(TRAINING_LAYOUT_STORAGE_KEY);
-    if (!raw) return false;
+    if (!raw) return null;
     try {
       const parsed = JSON.parse(raw) as DockviewLayout;
       suppressLayoutChangeRef.current = true;
       api.fromJSON(cloneDockLayout(parsed));
+      setOpenPanels(extractPanelIds(parsed));
       setCurrentLayout("saved");
       setHasSavedLayout(true);
       setTimeout(() => {
         suppressLayoutChangeRef.current = false;
       }, 0);
-      return true;
+      return parsed;
     } catch (err) {
       console.error("Failed to restore dock layout", err);
-      return false;
+      return null;
     }
-  }, []);
+  }, [setOpenPanels]);
 
   const handleDockReady = useCallback(
     (event: { api: DockviewApi }) => {
@@ -954,22 +962,26 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
     [applyLayout, loadSavedLayout]
   );
 
-  const handleLayoutChange = useCallback(() => {
-    if (suppressLayoutChangeRef.current) return;
-    if (pendingLayoutChangeRef.current) {
-      clearTimeout(pendingLayoutChangeRef.current);
-    }
-    pendingLayoutChangeRef.current = setTimeout(() => {
-      pendingLayoutChangeRef.current = null;
-      setCurrentLayout("custom");
-    }, 0);
-  }, []);
+  const handleLayoutChange = useCallback(
+    (layout: DockviewLayout) => {
+      setOpenPanels(extractPanelIds(layout));
+      if (suppressLayoutChangeRef.current) return;
+      if (pendingLayoutChangeRef.current) {
+        clearTimeout(pendingLayoutChangeRef.current);
+      }
+      pendingLayoutChangeRef.current = setTimeout(() => {
+        pendingLayoutChangeRef.current = null;
+        setCurrentLayout("custom");
+      }, 0);
+    },
+    [setOpenPanels]
+  );
 
   const handlePresetChange = useCallback(
     (value: string) => {
       if (value === "saved") {
-        const ok = loadSavedLayout();
-        if (!ok) {
+        const layout = loadSavedLayout();
+        if (!layout) {
           setHasSavedLayout(false);
         }
         return;
@@ -1001,8 +1013,8 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
   }, []);
 
   const handleLoadSaved = useCallback(() => {
-    const ok = loadSavedLayout();
-    if (!ok) {
+    const layout = loadSavedLayout();
+    if (!layout) {
       setHasSavedLayout(false);
     }
   }, [loadSavedLayout]);
@@ -1021,6 +1033,25 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
     if (!api) return;
     api.focusPanel(panelId);
   }, []);
+
+  const handlePanelLaunch = useCallback(
+    (panelKey: PanelKey) => {
+      const api = dockApiRef.current;
+      if (!api) return;
+      const panelDef = panelDefinitions[panelKey];
+      if (openPanels.includes(panelDef.id)) {
+        api.focusPanel(panelDef.id);
+        return;
+      }
+      api.addPanel({
+        id: panelDef.id,
+        component: panelDef.component,
+        title: panelDef.title,
+      });
+      setCurrentLayout("custom");
+    },
+    [openPanels, setCurrentLayout]
+  );
 
   const PanelBody = ({ children }: { children: React.ReactNode }) => (
     <div className="h-full overflow-auto space-y-4 p-4">{children}</div>
@@ -1718,6 +1749,31 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
                 Clear Saved
               </Button>
             )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <TooltipLabel className="text-xs" tooltip="Add, restore, or focus specific panels">
+              Panels
+            </TooltipLabel>
+            <div className="flex flex-wrap gap-2">
+              {Object.entries(panelDefinitions).map(([key, panel]) => {
+                const isOpen = openPanels.includes(panel.id);
+                return (
+                  <Button
+                    key={panel.id}
+                    size="sm"
+                    variant={isOpen ? "secondary" : "outline"}
+                    className="px-2"
+                    onClick={() => handlePanelLaunch(key as PanelKey)}
+                    disabled={!dockReady}
+                    title={isOpen ? "Focus panel" : "Add panel"}
+                  >
+                    <span className="font-mono text-xs">{isOpen ? "●" : "+"}</span>
+                    <span>{panel.title}</span>
+                  </Button>
+                );
+              })}
+            </div>
           </div>
 
           {!!tags && (

--- a/frontend/src/lib/dockview/index.tsx
+++ b/frontend/src/lib/dockview/index.tsx
@@ -39,7 +39,9 @@ export interface AddPanelOptions {
 export interface DockviewPanelApi {
   id: string;
   title: string;
-  updateOptions(options: { title?: string; params?: any }): void;
+  params?: any;
+  setTitle(title: string): void;
+  updateParameters(parameters: Record<string, any>): void;
   focus(): void;
   close(): void;
 }
@@ -48,6 +50,7 @@ export interface DockviewApi {
   addPanel(options: AddPanelOptions): DockviewPanelApi;
   closePanel(panelId: string): void;
   focusPanel(panelId: string): void;
+  getPanel(panelId: string): DockviewPanelApi | undefined;
   toJSON(): DockviewLayout;
   fromJSON(layout: DockviewLayout): void;
 }
@@ -58,7 +61,7 @@ export interface DockviewReadyEvent {
 
 export interface DockviewPanelProps<T = any> {
   params?: T;
-  panelApi: DockviewPanelApi;
+  api: DockviewPanelApi;
 }
 
 export interface DockviewReactProps {
@@ -157,21 +160,47 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
 
   const ensurePanelApi = useCallback(
     (panel: DockviewPanel): DockviewPanelApi => {
-      if (panelApis.current.has(panel.id)) {
-        return panelApis.current.get(panel.id)!;
+      const existing = panelApis.current.get(panel.id);
+      if (existing) {
+        existing.title = panel.title;
+        existing.params = panel.params;
+        return existing;
       }
       const api: DockviewPanelApi = {
         id: panel.id,
         title: panel.title,
-        updateOptions(options) {
+        params: panel.params,
+        setTitle(title) {
           setLayout((prev) => {
             const next = cloneLayout(prev);
             const loc = findPanel(panel.id);
             if (!loc) return prev;
             const target = next.groups[loc.groupIndex].tabs[loc.panelIndex];
-            if (options.title) target.title = options.title;
-            if (options.params !== undefined) target.params = options.params;
-            api.title = target.title;
+            target.title = title;
+            api.title = title;
+            return next;
+          });
+        },
+        updateParameters(parameters) {
+          setLayout((prev) => {
+            const next = cloneLayout(prev);
+            const loc = findPanel(panel.id);
+            if (!loc) return prev;
+            const target = next.groups[loc.groupIndex].tabs[loc.panelIndex];
+            if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
+              target.params = parameters;
+            } else {
+              const current = { ...(target.params ?? {}) } as Record<string, any>;
+              Object.entries(parameters).forEach(([key, value]) => {
+                if (value === undefined) {
+                  delete current[key];
+                } else {
+                  current[key] = value;
+                }
+              });
+              target.params = current;
+            }
+            api.params = target.params;
             return next;
           });
         },
@@ -179,6 +208,7 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
           focusPanelInternal(panel.id);
         },
         close() {
+          panelApis.current.delete(panel.id);
           removePanel(panel.id);
         },
       };
@@ -215,6 +245,14 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
 
   const addPanel = useCallback(
     (options: AddPanelOptions): DockviewPanelApi => {
+      if (options.id) {
+        const existing = findPanel(options.id);
+        if (existing) {
+          const panel = layoutRef.current.groups[existing.groupIndex].tabs[existing.panelIndex];
+          focusPanelInternal(panel.id);
+          return ensurePanelApi(panel);
+        }
+      }
       const panel: DockviewPanel = {
         id: options.id || createId("panel"),
         component: options.component,
@@ -247,7 +285,7 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
       insertPanel(panel, targetGroup, index, size);
       return ensurePanelApi(panel);
     },
-    [ensurePanelApi, findPanel, insertPanel]
+    [ensurePanelApi, findPanel, focusPanelInternal, insertPanel]
   );
 
   const closePanel = useCallback(
@@ -256,6 +294,16 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
       panelApis.current.delete(panelId);
     },
     [removePanel]
+  );
+
+  const getPanel = useCallback(
+    (panelId: string): DockviewPanelApi | undefined => {
+      const loc = findPanel(panelId);
+      if (!loc) return undefined;
+      const panel = layoutRef.current.groups[loc.groupIndex].tabs[loc.panelIndex];
+      return ensurePanelApi(panel);
+    },
+    [ensurePanelApi, findPanel]
   );
 
   const fromJSON = useCallback(
@@ -286,14 +334,21 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
       addPanel,
       closePanel,
       focusPanel: focusPanelInternal,
+      getPanel,
       toJSON,
       fromJSON,
     };
     onReady?.({ api });
-  }, [addPanel, closePanel, focusPanelInternal, fromJSON, onReady, toJSON]);
+  }, [addPanel, closePanel, focusPanelInternal, fromJSON, getPanel, onReady, toJSON]);
 
-  const handleDragStart = (panelId: string) => {
+  const handleDragStart = (event: React.DragEvent<HTMLElement>, panelId: string) => {
     draggingIdRef.current = panelId;
+    if (event.dataTransfer) {
+      event.dataTransfer.effectAllowed = "move";
+      try {
+        event.dataTransfer.setData("text/plain", panelId);
+      } catch {}
+    }
   };
 
   const handleDragEnd = () => {
@@ -525,7 +580,7 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
                       tabIndex={0}
                       className={["dv-tab", isActive ? "dv-tab-active" : ""].join(" ").trim()}
                       draggable
-                      onDragStart={() => handleDragStart(tab.id)}
+                      onDragStart={(event) => handleDragStart(event, tab.id)}
                       onDragEnd={handleDragEnd}
                       onClick={() => focusPanelInternal(tab.id)}
                       onKeyDown={(event) => {
@@ -573,7 +628,7 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
                         );
                       }
                       const api = ensurePanelApi(activePanel);
-                      return <Component params={activePanel.params} panelApi={api} />;
+                      return <Component params={activePanel.params} api={api} />;
                     })()}
                   </div>
                 ) : (


### PR DESCRIPTION
## Summary
- track active dock panels and surface controls to reopen or focus panels in training results
- enhance the custom dockview implementation with richer panel APIs, duplicate safety, and reliable drag metadata
- persist open panel state across preset loads and saved layouts for a smoother docking experience

## Testing
- npm run lint *(fails: next binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd8c0dcd083319204c8385d27504c