### PR TITLE
Prevent dock layout state churn when restoring panels

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults.tsx
@@ -917,6 +917,15 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
     };
   }, []);
 
+  const commitOpenPanels = useCallback((panelIds: string[]) => {
+    setOpenPanels((prev) => {
+      if (prev.length === panelIds.length && prev.every((id, idx) => id === panelIds[idx])) {
+        return prev;
+      }
+      return [...panelIds];
+    });
+  }, []);
+
   const updateOpenPanels = useCallback(
     (panelIds: string[], immediate = false) => {
       if (pendingOpenPanelsRef.current) {
@@ -924,15 +933,16 @@ export default function TrainingResults({ initialRunId }: { initialRunId?: strin
         pendingOpenPanelsRef.current = null;
       }
       if (immediate) {
-        setOpenPanels(panelIds);
+        commitOpenPanels(panelIds);
         return;
       }
+      const nextIds = [...panelIds];
       pendingOpenPanelsRef.current = setTimeout(() => {
         pendingOpenPanelsRef.current = null;
-        setOpenPanels(panelIds);
+        commitOpenPanels(nextIds);
       }, 0);
     },
-    [setOpenPanels]
+    [commitOpenPanels]
   );
 
   const applyLayout = useCallback(


### PR DESCRIPTION
## Summary
- prevent redundant open-panel state updates by comparing the requested ids before setting state
- reuse the guarded updater for both immediate and deferred dock layout updates to avoid cascaded renders

## Testing
- npm run lint *(fails: `next` binary missing because dependencies could not be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccdec81df88331b1d34d7987230fd9