### PR TITLE
Prevent repeated trade feed polling after 404 responses

### DIFF
--- a/frontend/src/components/Stockbot/run-monitor/usePaginatedFeed.ts
+++ b/frontend/src/components/Stockbot/run-monitor/usePaginatedFeed.ts
@@ -2,9 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { buildUrl } from "@/api/client";
 import type { PaginatedResult } from "./types";
 
+const NOT_FOUND_COOLDOWN_MS = 30_000;
+
 export function usePaginatedFeed<T>(runId: string | null, resource: string, limit = 500) {
   const loadingRef = useRef(false);
   const exhaustedRef = useRef(false);
+  const notFoundRef = useRef<number | null>(null);
+  const prevRunIdRef = useRef<string | null>(null);
   const [items, setItems] = useState<T[]>([]);
   const [cursor, setCursor] = useState<string | null>(null);
   const [hasMore, setHasMore] = useState(false);
@@ -14,6 +18,12 @@ export function usePaginatedFeed<T>(runId: string | null, resource: string, limi
   const loadPage = useCallback(
     async (cursorValue: string | null, reset: boolean, force = false) => {
       if (!runId) return;
+      if (cursorValue === null && !force && notFoundRef.current) {
+        const elapsed = Date.now() - notFoundRef.current;
+        if (elapsed < NOT_FOUND_COOLDOWN_MS) {
+          return;
+        }
+      }
       if (loadingRef.current) return;
       if (exhaustedRef.current && !force) return;
       loadingRef.current = true;
@@ -34,6 +44,7 @@ export function usePaginatedFeed<T>(runId: string | null, resource: string, limi
           setHasMore(false);
           setError(friendlyMessage);
           exhaustedRef.current = true;
+          notFoundRef.current = Date.now();
           return;
         }
         if (!resp.ok) throw new Error(`${resource} ${resp.status}`);
@@ -43,6 +54,9 @@ export function usePaginatedFeed<T>(runId: string | null, resource: string, limi
         setCursor(data?.next_cursor != null ? String(data.next_cursor) : null);
         setHasMore(Boolean(data?.has_more));
         setError(null);
+        if (cursorValue === null) {
+          notFoundRef.current = null;
+        }
       } catch (err: any) {
         setError(err?.message || `Failed to load ${resource}`);
       } finally {
@@ -54,6 +68,8 @@ export function usePaginatedFeed<T>(runId: string | null, resource: string, limi
   );
 
   useEffect(() => {
+    if (prevRunIdRef.current === runId) return;
+    prevRunIdRef.current = runId;
     setItems([]);
     setCursor(null);
     setHasMore(false);
@@ -61,6 +77,7 @@ export function usePaginatedFeed<T>(runId: string | null, resource: string, limi
     setLoading(false);
     loadingRef.current = false;
     exhaustedRef.current = false;
+    notFoundRef.current = null;
     if (!runId) return;
     loadPage(null, true);
   }, [runId, loadPage]);
@@ -72,7 +89,10 @@ export function usePaginatedFeed<T>(runId: string | null, resource: string, limi
 
   const reload = useCallback((options?: { force?: boolean }) => {
     if (!runId) return;
-    if (options?.force) exhaustedRef.current = false;
+    if (options?.force) {
+      exhaustedRef.current = false;
+      notFoundRef.current = null;
+    }
     loadPage(null, true, Boolean(options?.force));
   }, [runId, loadPage]);
 


### PR DESCRIPTION
## Summary
- add a cooldown after 404 responses in `usePaginatedFeed` to avoid hammering the API
- keep track of the last run id so we only reset pagination when the monitored run changes
- reset the new cooldown markers when forcing a reload so manual retries still work

## Testing
- `npm run lint` *(fails: next not installed in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68cde3c4fec48331993d98627a86c299