### PR TITLE
Fix dockview onReady callback handling in TrainingResults

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults/index.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/index.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { DockviewReact, type DockviewApi, type DockviewLayout } from "dockview";
+import {
+  DockviewReact,
+  type DockviewApi,
+  type DockviewLayout,
+  type DockviewReadyEvent,
+} from "dockview";
 import api, { buildUrl } from "@/api/client";
 import { deleteRun } from "@/api/stockbot";
 import type { RunSummary, Metrics, RunArtifacts } from "../lib/types";
@@ -533,11 +538,14 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
     [commitOpenPanels],
   );
 
-  const handleDockReady = useCallback((api: DockviewApi) => {
-    dockApiRef.current = api;
-    setDockReady(true);
-    updateOpenPanels(extractPanelIds(api.toJSON()), true);
-  }, [updateOpenPanels]);
+  const handleDockReady = useCallback(
+    ({ api }: DockviewReadyEvent) => {
+      dockApiRef.current = api;
+      setDockReady(true);
+      updateOpenPanels(extractPanelIds(api.toJSON()), true);
+    },
+    [updateOpenPanels],
+  );
 
   const handleLayoutChange = useCallback(
     (layout: DockviewLayout) => {


### PR DESCRIPTION
## Summary
- destructure the Dockview onReady event so the api reference exposes `toJSON`
- update the dockview import to include the ready event typing for clarity

## Testing
- npm run lint *(fails: `next: not found` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdec0dd1a08331991d1ab68aa0e9b1