### PR TITLE
feat: enable nested dock layouts with row and column splits

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults/dock-layouts.ts
+++ b/frontend/src/components/Stockbot/TrainingResults/dock-layouts.ts
@@ -1,4 +1,4 @@
-import type { DockviewLayout } from "dockview";
+import type { DockviewLayout, DockviewNode, DockviewGroupNode } from "dockview";
 
 export const TRAINING_LAYOUT_STORAGE_KEY = "stockbot:trainingResults:docklayout:v1";
 
@@ -17,87 +17,104 @@ const createPanel = <K extends keyof typeof panelDefinitions>(key: K) => ({
   ...panelDefinitions[key],
 });
 
-export const defaultDockLayout: DockviewLayout = {
-  groups: [
-    {
-      id: "group-overview",
-      size: 1.2,
-      active: panelDefinitions.overview.id,
-      tabs: [createPanel("overview"), createPanel("performance")],
+const group = (config: Omit<DockviewGroupNode, "type">): DockviewGroupNode => ({
+  type: "group",
+  ...config,
+});
+
+const horizontalLayout = (id: string, children: DockviewGroupNode[]): DockviewLayout => {
+  if (children.length === 0) {
+    return { version: "2", root: null };
+  }
+  if (children.length === 1) {
+    return { version: "2", root: children[0] };
+  }
+  return {
+    version: "2",
+    root: {
+      type: "split",
+      id,
+      orientation: "horizontal",
+      children,
     },
-    {
-      id: "group-behavior",
-      size: 1.1,
-      active: panelDefinitions.trades.id,
-      tabs: [createPanel("trades"), createPanel("risk"), createPanel("diagnostics")],
-    },
-    {
-      id: "group-data",
-      size: 1,
-      active: panelDefinitions.scalars.id,
-      tabs: [createPanel("scalars"), createPanel("artifacts")],
-    },
-    {
-      id: "group-monitor",
-      size: 1.2,
-      active: panelDefinitions.monitor.id,
-      tabs: [createPanel("monitor")],
-    },
-  ],
+  };
 };
 
-export const analysisDockLayout: DockviewLayout = {
-  groups: [
-    {
-      id: "group-core",
-      size: 1.6,
-      active: panelDefinitions.performance.id,
-      tabs: [
-        createPanel("overview"),
-        createPanel("performance"),
-        createPanel("diagnostics"),
-        createPanel("risk"),
-      ],
-    },
-    {
-      id: "group-context",
-      size: 1.2,
-      active: panelDefinitions.scalars.id,
-      tabs: [createPanel("scalars"), createPanel("trades"), createPanel("artifacts")],
-    },
-    {
-      id: "group-monitor-analysis",
-      size: 1,
-      active: panelDefinitions.monitor.id,
-      tabs: [createPanel("monitor")],
-    },
-  ],
-};
+export const defaultDockLayout: DockviewLayout = horizontalLayout("split-default", [
+  group({
+    id: "group-overview",
+    size: 1.2,
+    active: panelDefinitions.overview.id,
+    tabs: [createPanel("overview"), createPanel("performance")],
+  }),
+  group({
+    id: "group-behavior",
+    size: 1.1,
+    active: panelDefinitions.trades.id,
+    tabs: [createPanel("trades"), createPanel("risk"), createPanel("diagnostics")],
+  }),
+  group({
+    id: "group-data",
+    size: 1,
+    active: panelDefinitions.scalars.id,
+    tabs: [createPanel("scalars"), createPanel("artifacts")],
+  }),
+  group({
+    id: "group-monitor",
+    size: 1.2,
+    active: panelDefinitions.monitor.id,
+    tabs: [createPanel("monitor")],
+  }),
+]);
 
-export const compactDockLayout: DockviewLayout = {
-  groups: [
-    {
-      id: "group-all",
-      size: 1.8,
-      active: panelDefinitions.overview.id,
-      tabs: [
-        createPanel("overview"),
-        createPanel("performance"),
-        createPanel("trades"),
-        createPanel("risk"),
-        createPanel("diagnostics"),
-        createPanel("scalars"),
-        createPanel("artifacts"),
-      ],
-    },
-    {
-      id: "group-monitor-compact",
-      size: 1,
-      active: panelDefinitions.monitor.id,
-      tabs: [createPanel("monitor")],
-    },
-  ],
-};
+export const analysisDockLayout: DockviewLayout = horizontalLayout("split-analysis", [
+  group({
+    id: "group-core",
+    size: 1.6,
+    active: panelDefinitions.performance.id,
+    tabs: [
+      createPanel("overview"),
+      createPanel("performance"),
+      createPanel("diagnostics"),
+      createPanel("risk"),
+    ],
+  }),
+  group({
+    id: "group-context",
+    size: 1.2,
+    active: panelDefinitions.scalars.id,
+    tabs: [createPanel("scalars"), createPanel("trades"), createPanel("artifacts")],
+  }),
+  group({
+    id: "group-monitor-analysis",
+    size: 1,
+    active: panelDefinitions.monitor.id,
+    tabs: [createPanel("monitor")],
+  }),
+]);
+
+export const compactDockLayout: DockviewLayout = horizontalLayout("split-compact", [
+  group({
+    id: "group-all",
+    size: 1.8,
+    active: panelDefinitions.overview.id,
+    tabs: [
+      createPanel("overview"),
+      createPanel("performance"),
+      createPanel("trades"),
+      createPanel("risk"),
+      createPanel("diagnostics"),
+      createPanel("scalars"),
+      createPanel("artifacts"),
+    ],
+  }),
+  group({
+    id: "group-monitor-compact",
+    size: 1,
+    active: panelDefinitions.monitor.id,
+    tabs: [createPanel("monitor")],
+  }),
+]);
 
 export const DOCK_PRESETS: Array<{ id: string; label: string; layout: DockviewLayout }> = [
   { id: "default", label: "Default Columns", layout: defaultDockLayout },
@@ -107,12 +124,76 @@ export const DOCK_PRESETS: Array<{ id: string; label: string; layout: DockviewLa
 
 export type PanelKey = keyof typeof panelDefinitions;
 
-export const cloneDockLayout = (layout: DockviewLayout): DockviewLayout => ({
-  groups: layout.groups.map((group) => ({
-    ...group,
-    tabs: group.tabs.map((tab) => ({ ...tab })),
-  })),
-});
+const cloneNode = (node: DockviewNode): DockviewNode => {
+  if (node.type === "group") {
+    return {
+      ...node,
+      tabs: node.tabs.map((tab) => ({ ...tab })),
+    };
+  }
+  return {
+    ...node,
+    children: node.children.map(cloneNode),
+  };
+};
 
-export const extractPanelIds = (layout: DockviewLayout): string[] =>
-  layout.groups.flatMap((group) => group.tabs.map((tab) => tab.id));
+const hasRoot = (layout: unknown): layout is DockviewLayout =>
+  Boolean(layout && typeof layout === "object" && "root" in layout);
+
+const convertLegacy = (value: { groups?: any[] } | undefined): DockviewLayout => {
+  const groups = Array.isArray(value?.groups) ? value!.groups : [];
+  const nodes = groups
+    .map((legacy, index) => {
+      const rawTabs = Array.isArray(legacy?.tabs) ? legacy.tabs : [];
+      const tabs = rawTabs
+        .filter((tab: any) => tab && typeof tab.component === "string")
+        .map((tab: any, tabIndex: number) => ({
+          id:
+            typeof tab.id === "string"
+              ? tab.id
+              : `${tab.component}-${index}-${tabIndex}`,
+          component: tab.component,
+          title: typeof tab.title === "string" ? tab.title : tab.component,
+          params: tab.params,
+        }));
+      if (tabs.length === 0) return null;
+      const activeId =
+        typeof legacy?.active === "string" && tabs.some((tab) => tab.id === legacy.active)
+          ? legacy.active
+          : tabs[0].id;
+      return group({
+        id: typeof legacy?.id === "string" ? legacy.id : `group-${index}`,
+        size: typeof legacy?.size === "number" ? legacy.size : undefined,
+        active: activeId,
+        tabs,
+      });
+    })
+    .filter((node): node is DockviewGroupNode => node !== null);
+  return horizontalLayout("split-legacy", nodes);
+};
+
+export const cloneDockLayout = (layout: DockviewLayout | { groups?: any[] }): DockviewLayout => {
+  if (hasRoot(layout)) {
+    return {
+      version: "2",
+      root: layout.root ? cloneNode(layout.root) : null,
+    };
+  }
+  return convertLegacy(layout);
+};
+
+const collectPanels = (node: DockviewNode | null, acc: string[]) => {
+  if (!node) return;
+  if (node.type === "group") {
+    node.tabs.forEach((tab) => acc.push(tab.id));
+    return;
+  }
+  node.children.forEach((child) => collectPanels(child, acc));
+};
+
+export const extractPanelIds = (layout: DockviewLayout | { groups?: any[] }): string[] => {
+  const panels: string[] = [];
+  const source = hasRoot(layout) ? layout.root : convertLegacy(layout).root;
+  collectPanels(source ?? null, panels);
+  return panels;
+};

--- a/frontend/src/lib/dockview/dockview.css
+++ b/frontend/src/lib/dockview/dockview.css
@@ -1,27 +1,61 @@
+
 .dv-root {
+  position: relative;
   display: flex;
   width: 100%;
   height: 100%;
   background: transparent;
   box-sizing: border-box;
+  overflow: hidden;
+}
+
+.dv-node {
+  display: flex;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
 }
 
 .dv-drop-zone {
   flex: 0 0 auto;
   align-self: stretch;
   opacity: 0;
-  transition: opacity 0.15s ease, background 0.15s ease;
+  transition: opacity 0.15s ease, background 0.15s ease, outline 0.15s ease;
   border-radius: 0.375rem;
+  pointer-events: auto;
+  background: transparent;
 }
 
-.dv-drop-zone-outer {
+.dv-drop-zone-column {
   width: 0.65rem;
+  height: auto;
+}
+
+.dv-drop-zone-row {
+  width: 100%;
+  height: 0.65rem;
 }
 
 .dv-drop-zone.dv-drop-active {
   opacity: 1;
   background: rgba(59, 130, 246, 0.18);
   outline: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+.dv-split {
+  position: relative;
+  display: flex;
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
+}
+
+.dv-split-horizontal {
+  flex-direction: row;
+}
+
+.dv-split-vertical {
+  flex-direction: column;
 }
 
 .dv-splitter {
@@ -32,10 +66,17 @@
   justify-content: center;
 }
 
+.dv-splitter-vertical {
+  flex-direction: column;
+  width: 100%;
+  height: 0.7rem;
+}
+
 .dv-splitter .dv-drop-zone {
   position: absolute;
   inset: 0;
   width: auto;
+  height: auto;
   z-index: 0;
 }
 
@@ -54,6 +95,12 @@
   border-radius: 9999px;
 }
 
+.dv-resize-handle-vertical {
+  width: 100%;
+  height: 0.3rem;
+  cursor: row-resize;
+}
+
 .dv-resize-handle:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.45);
@@ -68,6 +115,11 @@
   transition: background 0.15s ease, transform 0.15s ease;
 }
 
+.dv-resize-handle-vertical .dv-resize-grip {
+  width: 38%;
+  height: 100%;
+}
+
 .dv-resize-handle:hover .dv-resize-grip,
 .dv-resize-handle:focus-visible .dv-resize-grip,
 .dv-resize-handle.dv-resize-active .dv-resize-grip {
@@ -75,9 +127,16 @@
   transform: scaleY(1.15);
 }
 
+.dv-resize-handle-vertical:hover .dv-resize-grip,
+.dv-resize-handle-vertical:focus-visible .dv-resize-grip,
+.dv-resize-handle-vertical.dv-resize-active .dv-resize-grip {
+  transform: scaleX(1.15);
+}
+
 .dv-group {
   display: flex;
   flex-direction: column;
+  position: relative;
   background: hsl(var(--card));
   border: 1px solid hsl(var(--border));
   border-radius: 0.75rem;
@@ -164,4 +223,77 @@
   font-size: 0.85rem;
   color: hsl(var(--muted-foreground));
   padding: 1rem;
+}
+
+.dv-empty-root {
+  border: 1px dashed hsl(var(--border));
+  border-radius: 0.75rem;
+  width: 100%;
+  height: 100%;
+  align-self: stretch;
+  background: rgba(148, 163, 184, 0.08);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.dv-empty-root[data-drop-active="true"] {
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+.dv-drop-target {
+  position: absolute;
+  opacity: 0;
+  border-radius: 0.75rem;
+  background: rgba(59, 130, 246, 0.08);
+  border: 1px dashed rgba(59, 130, 246, 0.2);
+  pointer-events: none;
+  transition: opacity 0.15s ease, background 0.15s ease, border 0.15s ease;
+  z-index: 5;
+}
+
+.dv-drop-target-enabled {
+  pointer-events: auto;
+}
+
+.dv-drop-target-active {
+  opacity: 1;
+  background: rgba(59, 130, 246, 0.2);
+  border-color: rgba(59, 130, 246, 0.45);
+}
+
+.dv-drop-target-center {
+  inset: 0.45rem;
+}
+
+.dv-drop-target-left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 24%;
+}
+
+.dv-drop-target-right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 24%;
+}
+
+.dv-drop-target-top {
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 28%;
+}
+
+.dv-drop-target-bottom {
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 28%;
+}
+
+.dv-tab[data-drop-active="true"] {
+  outline: 1px dashed rgba(59, 130, 246, 0.45);
+  outline-offset: 2px;
 }

--- a/frontend/src/lib/dockview/index.tsx
+++ b/frontend/src/lib/dockview/index.tsx
@@ -23,8 +23,23 @@ export interface DockviewGroup {
   active?: string;
 }
 
+export interface DockviewGroupNode extends DockviewGroup {
+  type: "group";
+}
+
+export interface DockviewSplitNode {
+  id: string;
+  type: "split";
+  size?: number;
+  orientation: "horizontal" | "vertical";
+  children: DockviewNode[];
+}
+
+export type DockviewNode = DockviewGroupNode | DockviewSplitNode;
+
 export interface DockviewLayout {
-  groups: DockviewGroup[];
+  root: DockviewNode | null;
+  version?: "2";
 }
 
 export interface AddPanelOptions {
@@ -35,7 +50,10 @@ export interface AddPanelOptions {
   size?: number;
   position?:
     | { groupId: string; index?: number }
-    | { referencePanelId: string; direction?: "left" | "right" | "center" };
+    | {
+        referencePanelId: string;
+        direction?: "left" | "right" | "top" | "bottom" | "center";
+      };
 }
 
 export interface DockviewPanelApi {
@@ -54,7 +72,7 @@ export interface DockviewApi {
   focusPanel(panelId: string): void;
   getPanel(panelId: string): DockviewPanelApi | undefined;
   toJSON(): DockviewLayout;
-  fromJSON(layout: DockviewLayout): void;
+  fromJSON(layout: DockviewLayout | { groups?: DockviewGroup[] }): void;
 }
 
 export interface DockviewReadyEvent {
@@ -75,31 +93,403 @@ export interface DockviewReactProps {
 }
 
 interface PanelLocation {
-  groupIndex: number;
+  groupPath: number[];
   panelIndex: number;
+  groupId: string;
 }
 
+interface GroupPathResult {
+  path: number[];
+  group: DockviewGroupNode;
+}
+
+type GroupDropPosition = "center" | "left" | "right" | "top" | "bottom";
+
+type DropTarget =
+  | {
+      type: "group";
+      path: number[];
+      position: GroupDropPosition;
+      tabIndex?: number;
+    }
+  | {
+      type: "split";
+      path: number[];
+      index: number;
+    };
+
+const isGroupNode = (node: DockviewNode | null): node is DockviewGroupNode =>
+  Boolean(node && node.type === "group");
+
+const isSplitNode = (node: DockviewNode | null): node is DockviewSplitNode =>
+  Boolean(node && node.type === "split");
+
+const clonePanel = (panel: DockviewPanel): DockviewPanel => ({ ...panel });
+
+const cloneNode = (node: DockviewNode): DockviewNode => {
+  if (isGroupNode(node)) {
+    return {
+      ...node,
+      tabs: node.tabs.map(clonePanel),
+    };
+  }
+  return {
+    ...node,
+    children: node.children.map(cloneNode),
+  };
+};
+
 const cloneLayout = (layout: DockviewLayout): DockviewLayout => ({
-  groups: layout.groups.map((group) => ({
-    ...group,
-    tabs: group.tabs.map((tab) => ({ ...tab })),
-  })),
+  root: layout.root ? cloneNode(layout.root) : null,
+  version: "2",
 });
 
-const findPanelInLayout = (
-  layout: DockviewLayout,
-  panelId: string
+const pathToKey = (path: number[]): string => (path.length === 0 ? "root" : path.join("."));
+
+const arraysEqual = (a: number[], b: number[]): boolean =>
+  a.length === b.length && a.every((value, index) => value === b[index]);
+
+const getNodeAtPath = (node: DockviewNode | null, path: number[]): DockviewNode | null => {
+  let current: DockviewNode | null = node;
+  for (const segment of path) {
+    if (!isSplitNode(current)) return null;
+    current = current.children[segment] ?? null;
+    if (!current) return null;
+  }
+  return current;
+};
+
+const findPanelInNode = (
+  node: DockviewNode,
+  panelId: string,
+  path: number[]
 ): PanelLocation | null => {
-  const groups = layout.groups;
-  for (let gi = 0; gi < groups.length; gi++) {
-    const tabs = groups[gi].tabs;
-    for (let pi = 0; pi < tabs.length; pi++) {
-      if (tabs[pi].id === panelId) {
-        return { groupIndex: gi, panelIndex: pi };
-      }
+  if (isGroupNode(node)) {
+    const index = node.tabs.findIndex((tab) => tab.id === panelId);
+    if (index !== -1) {
+      return { groupPath: path, panelIndex: index, groupId: node.id };
+    }
+    return null;
+  }
+  for (let i = 0; i < node.children.length; i++) {
+    const result = findPanelInNode(node.children[i], panelId, [...path, i]);
+    if (result) return result;
+  }
+  return null;
+};
+
+const findPanelInLayout = (layout: DockviewLayout, panelId: string): PanelLocation | null => {
+  if (!layout.root) return null;
+  return findPanelInNode(layout.root, panelId, []);
+};
+
+const findGroupPathById = (
+  node: DockviewNode | null,
+  groupId: string,
+  path: number[] = []
+): number[] | null => {
+  if (!node) return null;
+  if (isGroupNode(node)) {
+    return node.id === groupId ? path : null;
+  }
+  for (let i = 0; i < node.children.length; i++) {
+    const result = findGroupPathById(node.children[i], groupId, [...path, i]);
+    if (result) return result;
+  }
+  return null;
+};
+
+const findFirstGroupPath = (node: DockviewNode | null): GroupPathResult | null => {
+  if (!node) return null;
+  if (isGroupNode(node)) {
+    return { path: [], group: node };
+  }
+  for (let i = 0; i < node.children.length; i++) {
+    const child = node.children[i];
+    const result = findFirstGroupPath(child);
+    if (result) {
+      return {
+        path: [i, ...result.path],
+        group: result.group,
+      };
     }
   }
   return null;
+};
+
+const layoutContainsGroupId = (node: DockviewNode | null, groupId: string): boolean => {
+  if (!node) return false;
+  if (isGroupNode(node)) {
+    return node.id === groupId;
+  }
+  return node.children.some((child) => layoutContainsGroupId(child, groupId));
+};
+
+const removeGroupAtPath = (layout: DockviewLayout, path: number[]) => {
+  if (!layout.root) return;
+  if (path.length === 0) {
+    layout.root = null;
+    return;
+  }
+  const parentPath = path.slice(0, -1);
+  const parent = getNodeAtPath(layout.root, parentPath);
+  if (!isSplitNode(parent)) return;
+  const index = path[path.length - 1];
+  parent.children.splice(index, 1);
+};
+
+const normalizeNode = (node: DockviewNode | null): DockviewNode | null => {
+  if (!node) return null;
+  if (isGroupNode(node)) {
+    if (node.tabs.length === 0) {
+      return null;
+    }
+    if (node.active && !node.tabs.some((tab) => tab.id === node.active)) {
+      node.active = node.tabs[0]?.id;
+    }
+    return node;
+  }
+  const normalizedChildren: DockviewNode[] = [];
+  for (const child of node.children) {
+    const normalized = normalizeNode(child);
+    if (normalized) {
+      normalizedChildren.push(normalized);
+    }
+  }
+  node.children = normalizedChildren;
+  if (node.children.length === 0) {
+    return null;
+  }
+  if (node.children.length === 1) {
+    const only = node.children[0];
+    if (node.size !== undefined) {
+      only.size = node.size;
+    }
+    return only;
+  }
+  return node;
+};
+
+const normalizeLayout = (layout: DockviewLayout): DockviewLayout => ({
+  root: normalizeNode(layout.root),
+  version: "2",
+});
+
+const ensureGroupActive = (group: DockviewGroupNode) => {
+  if (!group.active || !group.tabs.some((tab) => tab.id === group.active)) {
+    group.active = group.tabs[0]?.id;
+  }
+};
+
+const insertPanelIntoGroup = (
+  layout: DockviewLayout,
+  path: number[],
+  panel: DockviewPanel,
+  index?: number
+): string | null => {
+  const node = getNodeAtPath(layout.root, path);
+  if (!isGroupNode(node)) return null;
+  let insertIndex = index;
+  if (insertIndex === undefined || insertIndex < 0 || insertIndex > node.tabs.length) {
+    node.tabs.push(panel);
+  } else {
+    node.tabs.splice(insertIndex, 0, panel);
+  }
+  node.active = panel.id;
+  return node.id;
+};
+
+const insertPanelAsSplitNode = (
+  layout: DockviewLayout,
+  path: number[],
+  position: Exclude<GroupDropPosition, "center">,
+  panel: DockviewPanel,
+  preferredSize?: number
+): string | null => {
+  const target = getNodeAtPath(layout.root, path);
+  if (!isGroupNode(target)) return null;
+
+  const orientation = position === "left" || position === "right" ? "horizontal" : "vertical";
+  const before = position === "left" || position === "top";
+  const targetBase = Math.max(target.size ?? 1, 0.5);
+  const newSize =
+    preferredSize !== undefined ? Math.max(preferredSize, 0.5) : Math.max(targetBase / 2, 0.5);
+  const targetSize = preferredSize !== undefined ? targetBase : Math.max(targetBase / 2, 0.5);
+  const newGroup: DockviewGroupNode = {
+    type: "group",
+    id: createId("group"),
+    tabs: [panel],
+    active: panel.id,
+    size: newSize,
+  };
+
+  if (path.length === 0) {
+    target.size = targetSize;
+    const split: DockviewSplitNode = {
+      type: "split",
+      id: createId("split"),
+      orientation,
+      children: before ? [newGroup, target] : [target, newGroup],
+    };
+    layout.root = split;
+    return newGroup.id;
+  }
+
+  const parentPath = path.slice(0, -1);
+  const parent = getNodeAtPath(layout.root, parentPath);
+  if (!isSplitNode(parent)) return null;
+  const childIndex = path[path.length - 1];
+
+  if (parent.orientation === orientation) {
+    const insertIndex = before ? childIndex : childIndex + 1;
+    target.size = targetSize;
+    parent.children.splice(insertIndex, 0, newGroup);
+    return newGroup.id;
+  }
+
+  const split: DockviewSplitNode = {
+    type: "split",
+    id: createId("split"),
+    orientation,
+    size: target.size,
+    children: before ? [newGroup, target] : [target, newGroup],
+  };
+  target.size = preferredSize !== undefined ? targetBase : 1;
+  newGroup.size = preferredSize !== undefined ? newSize : 1;
+  parent.children[childIndex] = split;
+  return newGroup.id;
+};
+
+const insertPanelIntoSplitNode = (
+  layout: DockviewLayout,
+  path: number[],
+  index: number,
+  panel: DockviewPanel,
+  preferredSize?: number
+): string | null => {
+  const split = getNodeAtPath(layout.root, path);
+  if (!isSplitNode(split)) return null;
+  const newGroup: DockviewGroupNode = {
+    type: "group",
+    id: createId("group"),
+    tabs: [panel],
+    active: panel.id,
+    size: preferredSize,
+  };
+  const clampedIndex = Math.max(0, Math.min(index, split.children.length));
+  if (split.children.length > 0) {
+    const neighborIndex = clampedIndex === split.children.length ? clampedIndex - 1 : clampedIndex;
+    const neighbor = split.children[neighborIndex];
+    const neighborBase = Math.max(neighbor.size ?? 1, 0.5);
+    if (preferredSize !== undefined) {
+      neighbor.size = neighborBase;
+      newGroup.size = Math.max(preferredSize, 0.5);
+    } else {
+      const half = Math.max(neighborBase / 2, 0.5);
+      neighbor.size = half;
+      newGroup.size = half;
+    }
+  } else {
+    newGroup.size = Math.max(preferredSize ?? 1, 0.5);
+  }
+  split.children.splice(clampedIndex, 0, newGroup);
+  return newGroup.id;
+};
+
+const collectPanelIds = (node: DockviewNode | null, result: string[]) => {
+  if (!node) return;
+  if (isGroupNode(node)) {
+    node.tabs.forEach((tab) => result.push(tab.id));
+    return;
+  }
+  node.children.forEach((child) => collectPanelIds(child, result));
+};
+
+const mapPanels = (
+  panels: DockviewPanel[] | undefined,
+  components: Record<string, React.ComponentType<DockviewPanelProps>>
+): DockviewPanel[] => {
+  if (!Array.isArray(panels)) return [];
+  return panels
+    .filter((panel): panel is DockviewPanel => Boolean(panel && components[panel.component]))
+    .map((panel) => ({
+      id: panel.id || createId("panel"),
+      component: panel.component,
+      title: panel.title || panel.component,
+      params: panel.params,
+    }));
+};
+
+const normalizeImportedNode = (
+  node: any,
+  components: Record<string, React.ComponentType<DockviewPanelProps>>
+): DockviewNode | null => {
+  if (!node) return null;
+  if (node.type === "split" || Array.isArray(node.children)) {
+    const orientation = node.orientation === "vertical" ? "vertical" : "horizontal";
+    const children = (node.children ?? [])
+      .map((child: any) => normalizeImportedNode(child, components))
+      .filter((child): child is DockviewNode => Boolean(child));
+    if (children.length === 0) return null;
+    return {
+      type: "split",
+      id: node.id || createId("split"),
+      orientation,
+      size: typeof node.size === "number" ? node.size : undefined,
+      children,
+    };
+  }
+  const tabs = mapPanels(node.tabs, components);
+  if (tabs.length === 0) return null;
+  const active = node.active && tabs.some((tab) => tab.id === node.active)
+    ? node.active
+    : tabs[0]?.id;
+  return {
+    type: "group",
+    id: node.id || createId("group"),
+    size: typeof node.size === "number" ? node.size : undefined,
+    active,
+    tabs,
+  };
+};
+
+const convertLegacyLayout = (
+  legacy: { groups?: DockviewGroup[] } | null | undefined,
+  components: Record<string, React.ComponentType<DockviewPanelProps>>
+): DockviewLayout => {
+  const groups = Array.isArray(legacy?.groups) ? legacy!.groups : [];
+  if (groups.length === 0) {
+    return { root: null, version: "2" };
+  }
+  const nodes = groups
+    .map((group) => ({
+      type: "group" as const,
+      id: group.id || createId("group"),
+      size: group.size,
+      active: group.active,
+      tabs: mapPanels(group.tabs, components),
+    }))
+    .filter((group) => group.tabs.length > 0);
+  if (nodes.length === 0) {
+    return { root: null, version: "2" };
+  }
+  if (nodes.length === 1) {
+    const single = nodes[0];
+    ensureGroupActive(single);
+    return { root: single, version: "2" };
+  }
+  return {
+    root: {
+      type: "split",
+      id: createId("split"),
+      orientation: "horizontal",
+      children: nodes.map((group) => {
+        ensureGroupActive(group);
+        return group;
+      }),
+    },
+    version: "2",
+  };
 };
 
 const createId = (() => {
@@ -115,13 +505,14 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
   onLayoutChange,
 }) => {
   const componentsRef = useRef(components);
-  const [layout, setLayoutState] = useState<DockviewLayout>({ groups: [] });
+  const [layout, setLayoutState] = useState<DockviewLayout>({ root: null, version: "2" });
   const layoutRef = useRef(layout);
   const draggingIdRef = useRef<string | null>(null);
   const [dragOver, setDragOver] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const resizeCleanupRef = useRef<(() => void) | null>(null);
-  const [resizingIndex, setResizingIndex] = useState<number | null>(null);
+  const [resizingHandle, setResizingHandle] = useState<string | null>(null);
   const panelApis = useRef(new Map<string, DockviewPanelApi>());
   const activeGroupIdRef = useRef<string | null>(null);
 
@@ -152,25 +543,31 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
         const next = cloneLayout(prev);
         const loc = findPanelInLayout(next, panelId);
         if (!loc) return prev;
-        const group = next.groups[loc.groupIndex];
-        if (!group) return prev;
+        const group = getNodeAtPath(next.root, loc.groupPath);
+        if (!isGroupNode(group)) return prev;
         const [removed] = group.tabs.splice(loc.panelIndex, 1);
         if (!removed) return prev;
         panelApis.current.delete(removed.id);
         if (group.active === panelId) {
-          group.active = group.tabs[0]?.id;
+          ensureGroupActive(group);
         }
         if (group.tabs.length === 0) {
-          next.groups.splice(loc.groupIndex, 1);
+          removeGroupAtPath(next, loc.groupPath);
           if (activeGroupIdRef.current === group.id) {
-            activeGroupIdRef.current =
-              next.groups[loc.groupIndex]?.id ?? next.groups[loc.groupIndex - 1]?.id ?? null;
+            activeGroupIdRef.current = null;
           }
         }
-        if (next.groups.length === 0) {
+        const normalized = normalizeLayout(next);
+        if (normalized.root && activeGroupIdRef.current) {
+          if (!layoutContainsGroupId(normalized.root, activeGroupIdRef.current)) {
+            const first = findFirstGroupPath(normalized.root);
+            activeGroupIdRef.current = first?.group.id ?? null;
+          }
+        }
+        if (!normalized.root) {
           activeGroupIdRef.current = null;
         }
-        return next;
+        return normalized;
       });
     },
     [setLayout]
@@ -182,8 +579,8 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
         const next = cloneLayout(prev);
         const loc = findPanelInLayout(next, panelId);
         if (!loc) return prev;
-        const group = next.groups[loc.groupIndex];
-        if (!group) return prev;
+        const group = getNodeAtPath(next.root, loc.groupPath);
+        if (!isGroupNode(group)) return prev;
         group.active = panelId;
         activeGroupIdRef.current = group.id;
         return next;
@@ -209,9 +606,10 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
             const next = cloneLayout(prev);
             const loc = findPanelInLayout(next, panel.id);
             if (!loc) return prev;
-            const group = next.groups[loc.groupIndex];
-            if (!group) return prev;
+            const group = getNodeAtPath(next.root, loc.groupPath);
+            if (!isGroupNode(group)) return prev;
             const target = group.tabs[loc.panelIndex];
+            if (!target) return prev;
             target.title = title;
             api.title = title;
             return next;
@@ -222,9 +620,10 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
             const next = cloneLayout(prev);
             const loc = findPanelInLayout(next, panel.id);
             if (!loc) return prev;
-            const group = next.groups[loc.groupIndex];
-            if (!group) return prev;
+            const group = getNodeAtPath(next.root, loc.groupPath);
+            if (!isGroupNode(group)) return prev;
             const target = group.tabs[loc.panelIndex];
+            if (!target) return prev;
             if (!parameters || typeof parameters !== "object" || Array.isArray(parameters)) {
               target.params = parameters;
             } else {
@@ -253,38 +652,78 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
       panelApis.current.set(panel.id, api);
       return api;
     },
-    [findPanel, focusPanelInternal, removePanel, setLayout]
+    [removePanel, focusPanelInternal, setLayout]
   );
 
-  const insertPanel = useCallback(
-    (panel: DockviewPanel, targetGroup: number, index?: number, size?: number) => {
+  const mutateInsert = useCallback(
+    (
+      layout: DockviewLayout,
+      panel: DockviewPanel,
+      target: DropTarget,
+      preferredSize?: number
+    ): string | null => {
+      if (target.type === "group") {
+        if (target.path.length === 0) {
+          const existingRoot = layout.root;
+          if (!existingRoot) {
+            const newGroup: DockviewGroupNode = {
+              type: "group",
+              id: createId("group"),
+              tabs: [panel],
+              active: panel.id,
+              size: preferredSize,
+            };
+            layout.root = newGroup;
+            return newGroup.id;
+          }
+        }
+        if (target.position === "center") {
+          return insertPanelIntoGroup(layout, target.path, panel, target.tabIndex);
+        }
+        return insertPanelAsSplitNode(layout, target.path, target.position, panel, preferredSize);
+      }
+      return insertPanelIntoSplitNode(layout, target.path, target.index, panel, preferredSize);
+    },
+    []
+  );
+
+  const movePanel = useCallback(
+    (panelId: string, target: DropTarget) => {
+      const source = findPanel(panelId);
+      if (!source) return;
       setLayout((prev) => {
         const next = cloneLayout(prev);
-        let targetIndex = targetGroup;
-        if (targetIndex < 0) targetIndex = 0;
-        if (targetIndex > next.groups.length) targetIndex = next.groups.length;
-        if (!next.groups[targetIndex]) {
-          next.groups.splice(targetIndex, 0, {
-            id: createId("group"),
-            tabs: [],
-            active: panel.id,
-            size,
-          });
+        const sourceGroup = getNodeAtPath(next.root, source.groupPath);
+        if (!isGroupNode(sourceGroup)) return prev;
+        const [panel] = sourceGroup.tabs.splice(source.panelIndex, 1);
+        if (!panel) return prev;
+        if (sourceGroup.active === panel.id) {
+          ensureGroupActive(sourceGroup);
         }
-        const group = next.groups[targetIndex];
-        if (!group) return prev;
-        if (size !== undefined) group.size = size;
-        if (index === undefined || index < 0 || index > group.tabs.length) {
-          group.tabs.push(panel);
-        } else {
-          group.tabs.splice(index, 0, panel);
+        if (sourceGroup.tabs.length === 0) {
+          removeGroupAtPath(next, source.groupPath);
+          if (activeGroupIdRef.current === sourceGroup.id) {
+            activeGroupIdRef.current = null;
+          }
         }
-        group.active = panel.id;
-        activeGroupIdRef.current = group.id;
-        return next;
+        if (
+          target.type === "group" &&
+          target.position === "center" &&
+          arraysEqual(source.groupPath, target.path) &&
+          target.tabIndex !== undefined &&
+          target.tabIndex > source.panelIndex
+        ) {
+          target = { ...target, tabIndex: target.tabIndex - 1 };
+        }
+        const targetGroupId = mutateInsert(next, panel, target);
+        if (!targetGroupId) return prev;
+        activeGroupIdRef.current = targetGroupId;
+        const normalized = normalizeLayout(next);
+        return normalized;
       });
+      setDragOver(null);
     },
-    [setLayout]
+    [findPanel, mutateInsert, setLayout]
   );
 
   const addPanel = useCallback(
@@ -292,9 +731,12 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
       if (options.id) {
         const existing = findPanel(options.id);
         if (existing) {
-          const panel = layoutRef.current.groups[existing.groupIndex].tabs[existing.panelIndex];
-          focusPanelInternal(panel.id);
-          return ensurePanelApi(panel);
+          const group = getNodeAtPath(layoutRef.current.root, existing.groupPath);
+          if (isGroupNode(group)) {
+            const panel = group.tabs[existing.panelIndex];
+            focusPanelInternal(panel.id);
+            return ensurePanelApi(panel);
+          }
         }
       }
       const panel: DockviewPanel = {
@@ -303,59 +745,101 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
         title: options.title,
         params: options.params,
       };
-      let targetGroup = layoutRef.current.groups.length;
-      let index: number | undefined = undefined;
-      let size = options.size;
+
+      const applyNewGroup = (group: DockviewGroupNode) => {
+        setLayout(() => ({ root: group, version: "2" }));
+        activeGroupIdRef.current = group.id;
+      };
+
+      if (!layoutRef.current.root) {
+        const group: DockviewGroupNode = {
+          type: "group",
+          id: createId("group"),
+          tabs: [panel],
+          active: panel.id,
+          size: options.size,
+        };
+        applyNewGroup(group);
+        return ensurePanelApi(panel);
+      }
+
+      let target: DropTarget | null = null;
+
       if (options.position && "groupId" in options.position) {
-        const groupIndex = layoutRef.current.groups.findIndex((g) => g.id === options.position!.groupId);
-        if (groupIndex !== -1) {
-          targetGroup = groupIndex;
-          index = options.position.index;
+        const path = findGroupPathById(layoutRef.current.root, options.position.groupId);
+        if (path) {
+          target = {
+            type: "group",
+            path,
+            position: "center",
+            tabIndex: options.position.index,
+          };
         }
       } else if (options.position && "referencePanelId" in options.position) {
         const loc = findPanel(options.position.referencePanelId);
         if (loc) {
-          targetGroup =
-            options.position.direction === "left"
-              ? loc.groupIndex
-              : options.position.direction === "center"
-              ? loc.groupIndex
-              : loc.groupIndex + 1;
-          if (options.position.direction === "center") {
-            index = loc.panelIndex + 1;
-          }
-        }
-      } else {
-        const layout = layoutRef.current;
-        const activeGroupId = activeGroupIdRef.current;
-        if (activeGroupId) {
-          const activeIndex = layout.groups.findIndex((g) => g.id === activeGroupId);
-          if (activeIndex !== -1) {
-            targetGroup = activeIndex;
-            index = layout.groups[activeIndex].tabs.length;
-          }
-        }
-        if (index === undefined && layout.groups.length > 0) {
-          const fallbackIndex = layout.groups.findIndex((g) => (g.active && g.tabs.length > 0) || g.tabs.length > 0);
-          if (fallbackIndex !== -1) {
-            targetGroup = fallbackIndex;
-            index = layout.groups[fallbackIndex].tabs.length;
+          const direction = options.position.direction || "center";
+          if (direction === "center") {
+            target = {
+              type: "group",
+              path: loc.groupPath,
+              position: "center",
+              tabIndex: loc.panelIndex + 1,
+            };
           } else {
-            targetGroup = layout.groups.length - 1;
-            index = layout.groups[targetGroup]?.tabs.length;
+            target = {
+              type: "group",
+              path: loc.groupPath,
+              position: direction,
+            };
           }
         }
       }
-      insertPanel(panel, targetGroup, index, size);
+
+      if (!target) {
+        let path: number[] | null = null;
+        if (activeGroupIdRef.current && layoutRef.current.root) {
+          path = findGroupPathById(layoutRef.current.root, activeGroupIdRef.current);
+        }
+        if (!path && layoutRef.current.root) {
+          const first = findFirstGroupPath(layoutRef.current.root);
+          path = first ? first.path : null;
+        }
+        if (path) {
+          target = { type: "group", path, position: "center" };
+        }
+      }
+
+      if (!target) {
+        const group: DockviewGroupNode = {
+          type: "group",
+          id: createId("group"),
+          tabs: [panel],
+          active: panel.id,
+          size: options.size,
+        };
+        applyNewGroup(group);
+        return ensurePanelApi(panel);
+      }
+
+      setLayout((prev) => {
+        const next = cloneLayout(prev);
+        const targetGroupId = mutateInsert(next, panel, target!, options.size);
+        if (!targetGroupId) return prev;
+        const normalized = normalizeLayout(next);
+        activeGroupIdRef.current = targetGroupId;
+        return normalized;
+      });
+
       return ensurePanelApi(panel);
     },
-    [ensurePanelApi, findPanel, focusPanelInternal, insertPanel]
+    [ensurePanelApi, findPanel, focusPanelInternal, mutateInsert, setLayout]
   );
 
   const closePanel = useCallback(
     (panelId: string) => {
-      removePanel(panelId);
       panelApis.current.delete(panelId);
+      removePanel(panelId);
     },
     [removePanel]
   );
@@ -364,30 +848,28 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
     (panelId: string): DockviewPanelApi | undefined => {
       const loc = findPanel(panelId);
       if (!loc) return undefined;
-      const panel = layoutRef.current.groups[loc.groupIndex].tabs[loc.panelIndex];
+      const group = getNodeAtPath(layoutRef.current.root, loc.groupPath);
+      if (!isGroupNode(group)) return undefined;
+      const panel = group.tabs[loc.panelIndex];
+      if (!panel) return undefined;
       return ensurePanelApi(panel);
     },
     [ensurePanelApi, findPanel]
   );
 
   const fromJSON = useCallback(
-    (nextLayout: DockviewLayout) => {
+    (nextLayout: DockviewLayout | { groups?: DockviewGroup[] }) => {
       const map = componentsRef.current;
-      const validGroups = (nextLayout.groups || []).map((group) => ({
-        id: group.id || createId("group"),
-        size: group.size,
-        active: group.active,
-        tabs: (group.tabs || [])
-          .filter((tab) => Boolean(map[tab.component]))
-          .map((tab) => ({
-            id: tab.id || createId("panel"),
-            component: tab.component,
-            title: tab.title || tab.component,
-            params: tab.params,
-          })),
-      }));
-      setLayout(() => ({ groups: validGroups }));
-      activeGroupIdRef.current = validGroups[0]?.id ?? null;
+      let normalized: DockviewLayout;
+      if (nextLayout && "root" in nextLayout) {
+        const rootNode = normalizeImportedNode(nextLayout.root, map);
+        normalized = normalizeLayout({ root: rootNode, version: "2" });
+      } else {
+        normalized = convertLegacyLayout(nextLayout, map);
+      }
+      setLayout(() => normalized);
+      const first = normalized.root ? findFirstGroupPath(normalized.root) : null;
+      activeGroupIdRef.current = first?.group.id ?? null;
       panelApis.current.clear();
     },
     [setLayout]
@@ -413,6 +895,7 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
 
   const handleDragStart = (event: React.DragEvent<HTMLElement>, panelId: string) => {
     draggingIdRef.current = panelId;
+    setIsDragging(true);
     if (event.dataTransfer) {
       event.dataTransfer.effectAllowed = "move";
       try {
@@ -424,93 +907,24 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
   const handleDragEnd = () => {
     draggingIdRef.current = null;
     setDragOver(null);
+    setIsDragging(false);
   };
 
-  const movePanel = useCallback(
-    (panelId: string, targetGroupIndex: number, targetIndex?: number, size?: number) => {
-      const loc = findPanel(panelId);
-      if (!loc) return;
-      if (loc.groupIndex === targetGroupIndex && (targetIndex === undefined || loc.panelIndex === targetIndex)) {
-        return;
-      }
-      setLayout((prev) => {
-        const next = cloneLayout(prev);
-        const currentLoc = findPanelInLayout(next, panelId);
-        if (!currentLoc) return prev;
-        const sourceGroup = next.groups[currentLoc.groupIndex];
-        const [removed] = sourceGroup.tabs.splice(currentLoc.panelIndex, 1);
-        if (!removed) {
-          return prev;
-        }
-        if (sourceGroup.active === removed.id) {
-          sourceGroup.active = sourceGroup.tabs[0]?.id;
-        }
-        let nextTargetGroupIndex = targetGroupIndex;
-        let nextTargetIndex = targetIndex;
-        if (sourceGroup.tabs.length === 0) {
-          next.groups.splice(currentLoc.groupIndex, 1);
-          if (activeGroupIdRef.current === sourceGroup.id) {
-            activeGroupIdRef.current = null;
-          }
-          if (nextTargetGroupIndex > currentLoc.groupIndex) nextTargetGroupIndex -= 1;
-        } else if (
-          nextTargetGroupIndex === currentLoc.groupIndex &&
-          nextTargetIndex !== undefined &&
-          nextTargetIndex > currentLoc.panelIndex
-        ) {
-          nextTargetIndex -= 1;
-        }
-        if (nextTargetGroupIndex < 0) {
-          nextTargetGroupIndex = 0;
-        }
-        if (nextTargetGroupIndex > next.groups.length) {
-          nextTargetGroupIndex = next.groups.length;
-        }
-        const target = next.groups[nextTargetGroupIndex];
-        if (target) {
-          if (size !== undefined) target.size = size;
-          if (
-            nextTargetIndex === undefined ||
-            nextTargetIndex < 0 ||
-            nextTargetIndex > target.tabs.length
-          ) {
-            target.tabs.push(removed);
-          } else {
-            target.tabs.splice(nextTargetIndex, 0, removed);
-          }
-          target.active = removed.id;
-          activeGroupIdRef.current = target.id;
-        } else {
-          const newGroup = {
-            id: createId("group"),
-            size,
-            active: removed.id,
-            tabs: [removed],
-          };
-          next.groups.splice(nextTargetGroupIndex, 0, newGroup);
-          activeGroupIdRef.current = newGroup.id;
-        }
-        return next;
-      });
-    },
-    [findPanel, setLayout]
-  );
-
-  const handleGroupDrop = (groupIndex: number, index?: number) => {
+  const handleGroupDrop = (
+    path: number[],
+    position: GroupDropPosition,
+    tabIndex?: number
+  ) => {
     const draggingId = draggingIdRef.current;
     if (!draggingId) return;
-    movePanel(draggingId, groupIndex, index);
-    setDragOver(null);
+    movePanel(draggingId, { type: "group", path, position, tabIndex });
   };
 
-  const handleCreateGroupDrop = (insertIndex: number) => {
+  const handleSplitDrop = (path: number[], index: number) => {
     const draggingId = draggingIdRef.current;
     if (!draggingId) return;
-    movePanel(draggingId, insertIndex, 0);
-    setDragOver(null);
+    movePanel(draggingId, { type: "split", path, index });
   };
-
-  const renderedGroups = useMemo(() => layout.groups, [layout.groups]);
 
   useEffect(() => {
     return () => {
@@ -522,253 +936,376 @@ export const DockviewReact: React.FC<DockviewReactProps> = ({
   }, []);
 
   const handleResizeStart = useCallback(
-    (groupIndex: number, event: React.PointerEvent<HTMLButtonElement>) => {
-      if (event.pointerType === "mouse" && event.button !== 0) return;
-      const container = containerRef.current;
-      if (!container) return;
-      const groups = layoutRef.current.groups;
-      if (!groups[groupIndex] || !groups[groupIndex + 1]) return;
-
+    (splitPath: number[], index: number, orientation: "horizontal" | "vertical", event: React.PointerEvent<HTMLButtonElement>) => {
       event.preventDefault();
-      event.stopPropagation();
-
-      const pointerId = event.pointerId;
-      const startX = event.clientX;
-      const containerWidth = container.getBoundingClientRect().width;
-      if (!Number.isFinite(containerWidth) || containerWidth <= 0) return;
-
-      const totalSize = groups.reduce((sum, g) => sum + (g.size ?? 1), 0);
-      const leftSize = groups[groupIndex].size ?? 1;
-      const rightSize = groups[groupIndex + 1].size ?? 1;
-      const pairTotal = leftSize + rightSize;
-      if (!Number.isFinite(pairTotal) || pairTotal <= 0) return;
-
-      const MIN_GROUP_WIDTH = 260;
-      const minNormalized = Math.min(
-        pairTotal / 2,
-        (MIN_GROUP_WIDTH / containerWidth) * totalSize
+      const splitKey = pathToKey(splitPath);
+      const target = event.currentTarget;
+      const container = target.closest(`[data-split-path="${splitKey}"]`) as HTMLElement | null;
+      const splitNode = getNodeAtPath(layoutRef.current.root, splitPath);
+      if (!container || !isSplitNode(splitNode)) return;
+      const childElements = Array.from(
+        container.querySelectorAll<HTMLElement>(":scope > .dv-node")
       );
+      if (childElements.length <= index || childElements.length <= index + 1) return;
+      const prevEl = childElements[index];
+      const nextEl = childElements[index + 1];
+      const prevRect = prevEl.getBoundingClientRect();
+      const nextRect = nextEl.getBoundingClientRect();
+      const prevSizePx = orientation === "horizontal" ? prevRect.width : prevRect.height;
+      const nextSizePx = orientation === "horizontal" ? nextRect.width : nextRect.height;
+      if (prevSizePx <= 0 || nextSizePx <= 0) return;
+      const startPos = orientation === "horizontal" ? event.clientX : event.clientY;
+      const minSize = 60;
+      const prevWeight = splitNode.children[index]?.size ?? 1;
+      const nextWeight = splitNode.children[index + 1]?.size ?? 1;
+      const totalWeight = prevWeight + nextWeight;
 
-      let lastLeft = leftSize;
-      let frame: number | null = null;
-
-      const updateSizes = (clientX: number) => {
-        const deltaPx = clientX - startX;
-        const deltaSize = (deltaPx / containerWidth) * totalSize;
-        let nextLeft = leftSize + deltaSize;
-        const clampMin = Number.isFinite(minNormalized) && minNormalized > 0 ? minNormalized : pairTotal / 2;
-        const lower = clampMin;
-        const upper = pairTotal - clampMin;
-        if (nextLeft < lower) nextLeft = lower;
-        if (nextLeft > upper) nextLeft = upper;
-        if (Math.abs(nextLeft - lastLeft) < 1e-4) return;
-        lastLeft = nextLeft;
-        const nextRight = pairTotal - nextLeft;
-        if (frame) cancelAnimationFrame(frame);
-        frame = window.requestAnimationFrame(() => {
-          setLayout((prev) => {
-            const next = cloneLayout(prev);
-            if (!next.groups[groupIndex] || !next.groups[groupIndex + 1]) return prev;
-            next.groups[groupIndex].size = nextLeft;
-            next.groups[groupIndex + 1].size = nextRight;
-            return next;
-          });
+      const handleMove = (moveEvent: PointerEvent) => {
+        const currentPos = orientation === "horizontal" ? moveEvent.clientX : moveEvent.clientY;
+        const delta = currentPos - startPos;
+        let newPrevPx = prevSizePx + delta;
+        let newNextPx = nextSizePx - delta;
+        const totalPx = prevSizePx + nextSizePx;
+        if (newPrevPx < minSize) {
+          newPrevPx = minSize;
+          newNextPx = totalPx - minSize;
+        } else if (newNextPx < minSize) {
+          newNextPx = minSize;
+          newPrevPx = totalPx - minSize;
+        }
+        if (newPrevPx <= 0 || newNextPx <= 0) return;
+        const ratio = newPrevPx / (newPrevPx + newNextPx);
+        const newPrevWeight = totalWeight * ratio;
+        const newNextWeight = totalWeight - newPrevWeight;
+        setLayout((prevLayout) => {
+          const updated = cloneLayout(prevLayout);
+          const split = getNodeAtPath(updated.root, splitPath);
+          if (!isSplitNode(split)) return prevLayout;
+          if (!split.children[index] || !split.children[index + 1]) return prevLayout;
+          split.children[index].size = newPrevWeight;
+          split.children[index + 1].size = newNextWeight;
+          return updated;
         });
       };
 
-      const handlePointerMove = (ev: PointerEvent) => {
-        if (ev.pointerId !== pointerId) return;
-        updateSizes(ev.clientX);
-      };
-
-      const cleanup = () => {
-        if (frame) {
-          cancelAnimationFrame(frame);
-          frame = null;
+      const handleUp = () => {
+        if (resizeCleanupRef.current) {
+          resizeCleanupRef.current();
+          resizeCleanupRef.current = null;
         }
-        window.removeEventListener("pointermove", handlePointerMove);
-        window.removeEventListener("pointerup", handlePointerUp);
-        window.removeEventListener("pointercancel", handlePointerUp);
-        try {
-          if (event.currentTarget.hasPointerCapture(pointerId)) {
-            event.currentTarget.releasePointerCapture(pointerId);
-          }
-        } catch {}
-        document.body.style.cursor = "";
-        resizeCleanupRef.current = null;
-        setDragOver((prev) => (prev && prev.startsWith("split-") ? null : prev));
-        setResizingIndex(null);
+        setResizingHandle(null);
       };
 
-      const handlePointerUp = (ev: PointerEvent) => {
-        if (ev.pointerId !== pointerId) return;
-        cleanup();
+      window.addEventListener("pointermove", handleMove);
+      window.addEventListener("pointerup", handleUp, { once: true });
+      resizeCleanupRef.current = () => {
+        window.removeEventListener("pointermove", handleMove);
+        window.removeEventListener("pointerup", handleUp);
       };
-
-      resizeCleanupRef.current?.();
-      resizeCleanupRef.current = cleanup;
-      setResizingIndex(groupIndex);
-      document.body.style.cursor = "col-resize";
-
-      window.addEventListener("pointermove", handlePointerMove);
-      window.addEventListener("pointerup", handlePointerUp);
-      window.addEventListener("pointercancel", handlePointerUp);
-
-      try {
-        event.currentTarget.setPointerCapture(pointerId);
-      } catch {}
+      setResizingHandle(`${splitKey}:${index}`);
     },
     [setLayout]
   );
 
-  return (
-    <div
-      ref={containerRef}
-      className={["dv-root", className || ""].join(" ").trim()}
-      style={style}
-    >
-      <div
-        className={["dv-drop-zone", "dv-drop-zone-outer", dragOver === "left" ? "dv-drop-active" : ""].join(" ").trim()}
-        onDragOver={(e) => {
-          if (draggingIdRef.current) {
+  const renderGroup = useCallback(
+    (group: DockviewGroupNode, path: number[]) => {
+      ensureGroupActive(group);
+      const activePanel = group.tabs.find((tab) => tab.id === group.active);
+      const groupKey = group.id;
+      const dropTargets: Array<{ position: GroupDropPosition; className: string }> = [
+        { position: "center", className: "dv-drop-target-center" },
+        { position: "left", className: "dv-drop-target-left" },
+        { position: "right", className: "dv-drop-target-right" },
+        { position: "top", className: "dv-drop-target-top" },
+        { position: "bottom", className: "dv-drop-target-bottom" },
+      ];
+      return (
+        <div
+          key={groupKey}
+          className="dv-group"
+          data-group-id={group.id}
+          onDragOver={(e) => {
+            if (!draggingIdRef.current) return;
             e.preventDefault();
-            setDragOver("left");
-          }
-        }}
-        onDragLeave={() => setDragOver(null)}
-        onDrop={(e) => {
-          e.preventDefault();
-          handleCreateGroupDrop(0);
-          setDragOver(null);
-        }}
-      />
-      {renderedGroups.map((group, groupIndex) => {
-        const activeId = group.active || group.tabs[0]?.id;
-        const activePanel = group.tabs.find((t) => t.id === activeId) || group.tabs[0];
-        return (
-          <React.Fragment key={group.id}>
-            <div
-              className="dv-group"
-              style={{ flexGrow: group.size ?? 1, flexBasis: 0 }}
-              onDragOver={(e) => {
-                if (!draggingIdRef.current) return;
-                e.preventDefault();
-                setDragOver(group.id);
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                if (draggingIdRef.current) {
-                  handleGroupDrop(groupIndex);
-                }
-                setDragOver(null);
-              }}
-            >
-              <div className="dv-tabs">
-                {group.tabs.map((tab, tabIndex) => {
-                  const Component = components[tab.component];
-                  const api = ensurePanelApi(tab);
-                  const isActive = tab.id === activeId;
-                  return (
-                    <div
-                      key={tab.id}
-                      role="tab"
-                      aria-selected={isActive}
-                      tabIndex={0}
-                      className={["dv-tab", isActive ? "dv-tab-active" : ""].join(" ").trim()}
-                      draggable
-                      onDragStart={(event) => handleDragStart(event, tab.id)}
-                      onDragEnd={handleDragEnd}
-                      onClick={() => focusPanelInternal(tab.id)}
-                      onKeyDown={(event) => {
-                        if (event.key === "Enter" || event.key === " ") {
-                          event.preventDefault();
-                          focusPanelInternal(tab.id);
-                        }
-                      }}
-                      onDragOver={(e) => {
-                        if (!draggingIdRef.current || draggingIdRef.current === tab.id) return;
-                        e.preventDefault();
-                        setDragOver(`${group.id}:${tab.id}`);
-                      }}
-                      onDrop={(e) => {
-                        e.preventDefault();
-                        const draggingId = draggingIdRef.current;
-                        if (!draggingId || draggingId === tab.id) return;
-                        handleGroupDrop(groupIndex, tabIndex);
-                        setDragOver(null);
-                      }}
-                    >
-                      <span className="dv-tab-title">{tab.title}</span>
-                      <button
-                        type="button"
-                        className="dv-tab-close"
-                        onClick={(ev) => {
-                          ev.stopPropagation();
-                          closePanel(tab.id);
-                        }}
-                      >
-                        ×
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
-              <div className="dv-group-content">
-                {activePanel ? (
-                  <div className="dv-panel">
-                    {(() => {
-                      const Component = components[activePanel.component];
-                      if (!Component) {
-                        return (
-                          <div className="dv-empty">Unknown component: {activePanel.component}</div>
-                        );
-                      }
-                      const api = ensurePanelApi(activePanel);
-                      return <Component params={activePanel.params} api={api} />;
-                    })()}
-                  </div>
-                ) : (
-                  <div className="dv-empty">Drop a panel here</div>
-                )}
-              </div>
-            </div>
-            <div className="dv-splitter">
+          }}
+          onDrop={(e) => {
+            if (!draggingIdRef.current) return;
+            e.preventDefault();
+            handleGroupDrop(path, "center");
+          }}
+        >
+          {isDragging &&
+            dropTargets.map(({ position, className }) => (
               <div
+                key={position}
                 className={[
-                  "dv-drop-zone",
-                  dragOver === `split-${groupIndex}` ? "dv-drop-active" : "",
-                ].join(" ").trim()}
+                  "dv-drop-target",
+                  className,
+                  isDragging ? "dv-drop-target-enabled" : "",
+                  dragOver === `group:${group.id}:${position}` ? "dv-drop-target-active" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
                 onDragOver={(e) => {
                   if (!draggingIdRef.current) return;
                   e.preventDefault();
-                  setDragOver(`split-${groupIndex}`);
+                  setDragOver(`group:${group.id}:${position}`);
                 }}
-                onDragLeave={() => setDragOver(null)}
+                onDragLeave={() => {
+                  setDragOver((prev) => (prev === `group:${group.id}:${position}` ? null : prev));
+                }}
                 onDrop={(e) => {
+                  if (!draggingIdRef.current) return;
                   e.preventDefault();
-                  handleCreateGroupDrop(groupIndex + 1);
+                  handleGroupDrop(path, position);
                   setDragOver(null);
                 }}
               />
-              {groupIndex < renderedGroups.length - 1 && (
-                <button
-                  type="button"
-                  aria-label="Resize panels"
-                  className={[
-                    "dv-resize-handle",
-                    resizingIndex === groupIndex ? "dv-resize-active" : "",
-                  ]
-                    .join(" ")
-                    .trim()}
-                  onPointerDown={(e) => handleResizeStart(groupIndex, e)}
+            ))}
+          <div className="dv-tabs">
+            {group.tabs.map((tab, tabIndex) => {
+              ensurePanelApi(tab);
+              const isActive = tab.id === activePanel?.id;
+              const tabKey = `tab:${group.id}:${tab.id}`;
+              return (
+                <div
+                  key={tab.id}
+                  role="tab"
+                  aria-selected={isActive}
+                  tabIndex={0}
+                  className={["dv-tab", isActive ? "dv-tab-active" : ""].join(" ").trim()}
+                  draggable
+                  onDragStart={(event) => handleDragStart(event, tab.id)}
+                  onDragEnd={handleDragEnd}
+                  onClick={() => focusPanelInternal(tab.id)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === " ") {
+                      event.preventDefault();
+                      focusPanelInternal(tab.id);
+                    }
+                  }}
+                  onDragOver={(e) => {
+                    if (!draggingIdRef.current || draggingIdRef.current === tab.id) return;
+                    e.preventDefault();
+                    setDragOver(tabKey);
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const draggingId = draggingIdRef.current;
+                    if (!draggingId || draggingId === tab.id) return;
+                    handleGroupDrop(path, "center", tabIndex);
+                    setDragOver(null);
+                  }}
+                  data-drop-active={dragOver === tabKey}
                 >
-                  <span className="dv-resize-grip" />
-                </button>
-              )}
-            </div>
-          </React.Fragment>
-        );
-      })}
+                  <span className="dv-tab-title">{tab.title}</span>
+                  <button
+                    type="button"
+                    className="dv-tab-close"
+                    onClick={(ev) => {
+                      ev.stopPropagation();
+                      closePanel(tab.id);
+                    }}
+                  >
+                    ×
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          <div className="dv-group-content">
+            {activePanel ? (
+              <div className="dv-panel">
+                {(() => {
+                  const Component = components[activePanel.component];
+                  if (!Component) {
+                    return <div className="dv-empty">Unknown component: {activePanel.component}</div>;
+                  }
+                  const api = ensurePanelApi(activePanel);
+                  return <Component params={activePanel.params} api={api} />;
+                })()}
+              </div>
+            ) : (
+              <div className="dv-empty">Drop a panel here</div>
+            )}
+          </div>
+        </div>
+      );
+    },
+    [
+      closePanel,
+      components,
+      ensurePanelApi,
+      focusPanelInternal,
+      handleDragEnd,
+      handleDragStart,
+      handleGroupDrop,
+      isDragging,
+      setDragOver,
+      dragOver,
+    ]
+  );
+
+  const renderNode = useCallback(
+    (node: DockviewNode, path: number[] = []) => {
+      if (isGroupNode(node)) {
+        return renderGroup(node, path);
+      }
+      const orientationClass = node.orientation === "vertical" ? "dv-split-vertical" : "dv-split-horizontal";
+      const splitKey = pathToKey(path);
+      return (
+        <div
+          key={node.id}
+          className={["dv-split", orientationClass].join(" ").trim()}
+          data-split-path={splitKey}
+        >
+          {node.children.map((child, index) => {
+            const beforeKey = `split:${splitKey}:${index}`;
+            const childPath = [...path, index];
+            return (
+              <React.Fragment key={child.id}>
+                <div
+                  className={[
+                    "dv-drop-zone",
+                    node.orientation === "vertical" ? "dv-drop-zone-row" : "dv-drop-zone-column",
+                    dragOver === beforeKey ? "dv-drop-active" : "",
+                  ]
+                    .filter(Boolean)
+                    .join(" ")}
+                  onDragOver={(e) => {
+                    if (!draggingIdRef.current) return;
+                    e.preventDefault();
+                    setDragOver(beforeKey);
+                  }}
+                  onDragLeave={() => {
+                    setDragOver((prev) => (prev === beforeKey ? null : prev));
+                  }}
+                  onDrop={(e) => {
+                    if (!draggingIdRef.current) return;
+                    e.preventDefault();
+                    handleSplitDrop(path, index);
+                    setDragOver(null);
+                  }}
+                />
+                <div className="dv-node" style={{ flexGrow: child.size ?? 1, flexBasis: 0 }}>
+                  {renderNode(child, childPath)}
+                </div>
+                {index === node.children.length - 1 && (
+                  <div
+                    className={[
+                      "dv-drop-zone",
+                      node.orientation === "vertical" ? "dv-drop-zone-row" : "dv-drop-zone-column",
+                      dragOver === `split:${splitKey}:${index + 1}` ? "dv-drop-active" : "",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                    onDragOver={(e) => {
+                      if (!draggingIdRef.current) return;
+                      e.preventDefault();
+                      setDragOver(`split:${splitKey}:${index + 1}`);
+                    }}
+                    onDragLeave={() => {
+                      setDragOver((prev) => (prev === `split:${splitKey}:${index + 1}` ? null : prev));
+                    }}
+                    onDrop={(e) => {
+                      if (!draggingIdRef.current) return;
+                      e.preventDefault();
+                      handleSplitDrop(path, index + 1);
+                      setDragOver(null);
+                    }}
+                  />
+                )}
+                {index < node.children.length - 1 && (
+                  <div
+                    className={["dv-splitter", node.orientation === "vertical" ? "dv-splitter-vertical" : ""].join(" ")}
+                  >
+                    <div
+                      className={[
+                        "dv-drop-zone",
+                        node.orientation === "vertical" ? "dv-drop-zone-row" : "dv-drop-zone-column",
+                        dragOver === `split:${splitKey}:between:${index}` ? "dv-drop-active" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      onDragOver={(e) => {
+                        if (!draggingIdRef.current) return;
+                        e.preventDefault();
+                        setDragOver(`split:${splitKey}:between:${index}`);
+                      }}
+                      onDragLeave={() => {
+                        setDragOver((prev) => (prev === `split:${splitKey}:between:${index}` ? null : prev));
+                      }}
+                      onDrop={(e) => {
+                        if (!draggingIdRef.current) return;
+                        e.preventDefault();
+                        handleSplitDrop(path, index + 1);
+                        setDragOver(null);
+                      }}
+                    />
+                    <button
+                      type="button"
+                      aria-label="Resize panels"
+                      className={[
+                        "dv-resize-handle",
+                        node.orientation === "vertical" ? "dv-resize-handle-vertical" : "",
+                        resizingHandle === `${splitKey}:${index}` ? "dv-resize-active" : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                      onPointerDown={(e) => handleResizeStart(path, index, node.orientation, e)}
+                    >
+                      <span className="dv-resize-grip" />
+                    </button>
+                  </div>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </div>
+      );
+    },
+    [dragOver, handleResizeStart, handleSplitDrop, renderGroup, resizingHandle, setDragOver]
+  );
+
+  const handleEmptyDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!draggingIdRef.current) return;
+    event.preventDefault();
+    movePanel(draggingIdRef.current, { type: "group", path: [], position: "center" });
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className={["dv-root", className ?? ""].join(" ").trim()}
+      style={style}
+      onDragOver={(e) => {
+        if (!draggingIdRef.current) return;
+        e.preventDefault();
+        if (!layout.root) {
+          setDragOver("root");
+        }
+      }}
+      onDrop={(e) => {
+        if (!draggingIdRef.current || layout.root) return;
+        handleEmptyDrop(e);
+        setDragOver(null);
+      }}
+    >
+      {layout.root ? (
+        <div className="dv-node" style={{ flexGrow: layout.root.size ?? 1, flexBasis: 0 }}>
+          {renderNode(layout.root, [])}
+        </div>
+      ) : (
+        <div className="dv-empty dv-empty-root" data-drop-active={dragOver === "root"}>
+          Drop a panel to get started
+        </div>
+      )}
     </div>
   );
+};
+
+export const extractLayoutPanelIds = (layout: DockviewLayout): string[] => {
+  const result: string[] = [];
+  collectPanelIds(layout.root, result);
+  return result;
 };


### PR DESCRIPTION
## Summary
- replace the Dockview shim with a tree-based layout engine that supports nested horizontal/vertical splits, richer drag targets, and panel resizing
- refresh Dockview styles for the new split containers, vertical handles, drop overlays, and empty state messaging
- migrate Training Results dock presets and helpers to the new layout model while preserving legacy layout compatibility

## Testing
- npm run lint *(fails: `next` missing because npm install is blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cdf5c70c2083319e1cf6a74bd53645