### PR TITLE
Initialize Dockview layout with saved/default configuration

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults/index.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/index.tsx
@@ -538,13 +538,57 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
     [commitOpenPanels],
   );
 
+  const applyLayout = useCallback(
+    (layout: DockviewLayout | { groups?: any[] }, presetId: string) => {
+      const api = dockApiRef.current;
+      if (!api) return;
+      suppressLayoutChangeRef.current = true;
+      try {
+        api.fromJSON(cloneDockLayout(layout));
+        setCurrentLayout(presetId);
+        updateOpenPanels(extractPanelIds(layout), true);
+      } finally {
+        suppressLayoutChangeRef.current = false;
+      }
+    },
+    [updateOpenPanels],
+  );
+
   const handleDockReady = useCallback(
     ({ api }: DockviewReadyEvent) => {
       dockApiRef.current = api;
       setDockReady(true);
-      updateOpenPanels(extractPanelIds(api.toJSON()), true);
+
+      let initialLayout: DockviewLayout | { groups?: any[] } = defaultDockLayout;
+      let layoutId: string = "default";
+
+      if (typeof window !== "undefined") {
+        try {
+          const raw = localStorage.getItem(TRAINING_LAYOUT_STORAGE_KEY);
+          if (raw) {
+            const parsed = JSON.parse(raw) as DockviewLayout | { groups?: any[] };
+            initialLayout = parsed;
+            layoutId = "saved";
+          }
+        } catch {
+          initialLayout = defaultDockLayout;
+          layoutId = "default";
+        }
+      }
+
+      try {
+        applyLayout(initialLayout, layoutId);
+      } catch {
+        if (layoutId === "saved") {
+          try {
+            localStorage.removeItem(TRAINING_LAYOUT_STORAGE_KEY);
+            setHasSavedLayout(false);
+          } catch {}
+          applyLayout(defaultDockLayout, "default");
+        }
+      }
     },
-    [updateOpenPanels],
+    [applyLayout, setHasSavedLayout],
   );
 
   const handleLayoutChange = useCallback(
@@ -564,29 +608,13 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
     [updateOpenPanels],
   );
 
-  const applyLayout = useCallback(
-    (layout: DockviewLayout, presetId: string) => {
-      const api = dockApiRef.current;
-      if (!api) return;
-      suppressLayoutChangeRef.current = true;
-      try {
-        api.fromJSON(cloneDockLayout(layout));
-        setCurrentLayout(presetId);
-        updateOpenPanels(extractPanelIds(layout), true);
-      } finally {
-        suppressLayoutChangeRef.current = false;
-      }
-    },
-    [updateOpenPanels],
-  );
-
   const handlePresetChange = useCallback(
     (presetId: string) => {
       if (presetId === "saved") {
         try {
           const raw = localStorage.getItem(TRAINING_LAYOUT_STORAGE_KEY);
           if (!raw) return;
-          const parsed = JSON.parse(raw) as DockviewLayout;
+          const parsed = JSON.parse(raw) as DockviewLayout | { groups?: any[] };
           applyLayout(parsed, "saved");
         } catch {}
         return;
@@ -616,7 +644,7 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
     try {
       const raw = localStorage.getItem(TRAINING_LAYOUT_STORAGE_KEY);
       if (!raw) return;
-      const parsed = JSON.parse(raw) as DockviewLayout;
+      const parsed = JSON.parse(raw) as DockviewLayout | { groups?: any[] };
       applyLayout(parsed, "saved");
     } catch {}
   }, [applyLayout]);


### PR DESCRIPTION
## Summary
- apply the saved or default dock layout when the Training Results dockview is ready so tabs populate their configured groups
- allow preset and saved layout loading to handle legacy layouts when cloning the layout definition
- fall back to the default layout and clear corrupt saved state if restoring the saved layout fails

## Testing
- npm run lint *(fails: next not found because dependencies are not installed in the execution environment)*
- npm install *(fails: npm registry returns 403 so dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdfb2cfff48331afa87962b83bd5db