### PR TITLE
Stabilized tensorboard polling by caching mutable state in refs

### DIFF
--- a/frontend/src/components/Stockbot/TrainingResults/hooks/useRunSelection.ts
+++ b/frontend/src/components/Stockbot/TrainingResults/hooks/useRunSelection.ts
@@ -4,9 +4,14 @@ import api from "@/api/client";
 import { deleteRun } from "@/api/stockbot";
 
 import type { RunSummary } from "../../lib/types";
+import {
+  clearRunsCache,
+  fetchRunsCached,
+  getRunsCacheSnapshot,
+} from "../../lib/runs";
 
 export function useRunSelection(initialRunId?: string) {
-  const [runs, setRuns] = useState<RunSummary[]>([]);
+  const [runs, setRuns] = useState<RunSummary[]>(() => getRunsCacheSnapshot() ?? []);
   const [runId, setRunId] = useState<string>(initialRunId || "");
 
   useEffect(() => {
@@ -15,21 +20,28 @@ export function useRunSelection(initialRunId?: string) {
     }
   }, [initialRunId, runId]);
 
-  const fetchRuns = useCallback(async () => {
-    try {
-      const { data } = await api.get<RunSummary[]>("/stockbot/runs");
-      return (data || []).filter((run) => run.type === "train");
-    } catch {
-      return [];
-    }
-  }, []);
+  const fetchRuns = useCallback(
+    async (options?: { force?: boolean }) => {
+      const nextRuns = await fetchRunsCached(
+        async () => {
+          try {
+            const { data } = await api.get<RunSummary[]>("/stockbot/runs");
+            return (data || []).filter((run) => run.type === "train");
+          } catch {
+            return [];
+          }
+        },
+        { force: options?.force },
+      );
+      setRuns(nextRuns);
+      return nextRuns;
+    },
+    [],
+  );
 
   useEffect(() => {
     if (runs.length > 0) return;
-    void (async () => {
-      const nextRuns = await fetchRuns();
-      setRuns(nextRuns);
-    })();
+    void fetchRuns();
   }, [runs.length, fetchRuns]);
 
   useEffect(() => {
@@ -37,7 +49,6 @@ export function useRunSelection(initialRunId?: string) {
     void (async () => {
       const existingRuns = runs.length ? runs : await fetchRuns();
       if (existingRuns.length && !runId) {
-        setRuns(existingRuns);
         setRunId(existingRuns[0].id);
       }
     })();
@@ -48,20 +59,20 @@ export function useRunSelection(initialRunId?: string) {
     if (!window.confirm("Delete this run?")) return;
     try {
       await deleteRun(runId);
-      const nextRuns = runs.filter((run) => run.id !== runId);
-      setRuns(nextRuns);
+      clearRunsCache();
+      const nextRuns = await fetchRuns({ force: true });
       setRunId(nextRuns[0]?.id || "");
     } catch (error) {
       console.error(error);
     }
-  }, [runId, runs]);
+  }, [runId, fetchRuns]);
 
   return {
     runs,
     setRuns,
     runId,
     setRunId,
-    refreshRuns: fetchRuns,
+    refreshRuns: () => fetchRuns({ force: true }),
     handleDeleteRun,
   } as const;
 }

--- a/frontend/src/components/Stockbot/TrainingResults/hooks/useSeedAggregates.ts
+++ b/frontend/src/components/Stockbot/TrainingResults/hooks/useSeedAggregates.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import api from "@/api/client";
 
 import { pickFirst, statTriple } from "../utils";
+import { fetchRunsCached } from "../../lib/runs";
 import type { Metrics, RunArtifacts, RunSummary } from "../../lib/types";
 import type { SeedAggregates, TBPoint, TBTags } from "../types";
 
@@ -25,8 +26,15 @@ export function useSeedAggregates({ runId, tags, needsSeedAggregates }: UseSeedA
     seedAggStatusRef.current = { runId, ready: false };
     try {
       const base = runId.replace(/-seed\d+$/i, "");
-      const { data: allRuns } = await api.get<RunSummary[]>("/stockbot/runs");
-      const seeds = (allRuns || []).filter((run) => run.type === "train" && run.id.startsWith(base));
+      const allRuns = await fetchRunsCached(async () => {
+        try {
+          const { data } = await api.get<RunSummary[]>("/stockbot/runs");
+          return (data || []).filter((run) => run.type === "train");
+        } catch {
+          return [];
+        }
+      });
+      const seeds = allRuns.filter((run) => run.id.startsWith(base));
       if (seeds.length <= 1) {
         setSeedAgg({});
         seedAggStatusRef.current = { runId, ready: true };

--- a/frontend/src/components/Stockbot/TrainingResults/hooks/useTensorboardData.ts
+++ b/frontend/src/components/Stockbot/TrainingResults/hooks/useTensorboardData.ts
@@ -12,6 +12,27 @@ export type UseTensorboardDataOptions = {
   needsGradients: boolean;
 };
 
+const DEFAULT_TAGS = [
+  "rollout/ep_rew_mean",
+  "eval/mean_reward",
+  "train/episode_reward",
+  "rollout/ep_len_mean",
+  "train/value_loss",
+  "train/policy_loss",
+  "train/policy_gradient_loss",
+  "train/entropy_loss",
+  "train/entropy",
+  "train/learning_rate",
+  "train/clip_fraction",
+  "train/clipfrac",
+  "train/approx_kl",
+  "train/kl",
+  "time/fps",
+  "grads/global_norm",
+] as const;
+
+const TIMER_THROTTLE_MS = 2000;
+
 export function useTensorboardData({
   runId,
   selectedTags,
@@ -25,13 +46,20 @@ export function useTensorboardData({
   const [loading, setLoading] = useState(false);
   const busyRef = useRef(false);
   const tickRef = useRef(0);
+  const tagsRef = useRef<TBTags | null>(null);
+  const lastReloadRef = useRef(0);
 
   useEffect(() => {
     setTags(null);
     setSeries({});
     setGradMatrix(null);
     tickRef.current = 0;
+    lastReloadRef.current = 0;
   }, [runId]);
+
+  useEffect(() => {
+    tagsRef.current = tags;
+  }, [tags]);
 
   const reload = useCallback(
     async (fromTimer = false) => {
@@ -43,30 +71,16 @@ export function useTensorboardData({
 
       if (!shouldLoadSeries && !shouldLoadTags && !shouldLoadGradients) return;
 
+      const now = Date.now();
+      if (fromTimer && now - lastReloadRef.current < TIMER_THROTTLE_MS) return;
+
       busyRef.current = true;
+      lastReloadRef.current = now;
       setLoading(true);
       try {
         const batchPromise = shouldLoadSeries
           ? (async () => {
-              const defaultTags = [
-                "rollout/ep_rew_mean",
-                "eval/mean_reward",
-                "train/episode_reward",
-                "rollout/ep_len_mean",
-                "train/value_loss",
-                "train/policy_loss",
-                "train/policy_gradient_loss",
-                "train/entropy_loss",
-                "train/entropy",
-                "train/learning_rate",
-                "train/clip_fraction",
-                "train/clipfrac",
-                "train/approx_kl",
-                "train/kl",
-                "time/fps",
-                "grads/global_norm",
-              ];
-              const wanted = Array.from(new Set([...defaultTags, ...selectedTags]));
+              const wanted = Array.from(new Set([...DEFAULT_TAGS, ...selectedTags]));
               return api
                 .get<{ series: Record<string, TBPoint[]> }>(
                   `/stockbot/runs/${runId}/tb/scalars-batch`,
@@ -76,8 +90,9 @@ export function useTensorboardData({
             })()
           : Promise.resolve(null);
 
+        const tagsSnapshot = tagsRef.current;
         const shouldGetTags =
-          shouldLoadTags && (!fromTimer || tickRef.current++ % 3 === 0 || !tags);
+          shouldLoadTags && (!fromTimer || tickRef.current++ % 3 === 0 || !tagsSnapshot);
 
         const tagsPromise = shouldGetTags
           ? api.get<TBTags>(`/stockbot/runs/${runId}/tb/tags`).catch(() => null)
@@ -103,7 +118,7 @@ export function useTensorboardData({
         busyRef.current = false;
       }
     },
-    [runId, selectedTags, needsTensorboard, needsTags, needsGradients, tags],
+    [runId, selectedTags, needsTensorboard, needsTags, needsGradients],
   );
 
   return {

--- a/frontend/src/components/Stockbot/TrainingResults/index.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/index.tsx
@@ -107,6 +107,7 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
     return visiblePanels;
   }, [dockReady, visiblePanels, consideredPanelIds]);
   const activePanelSet = useMemo(() => new Set(activePanels), [activePanels]);
+  const activePanelsKey = useMemo(() => activePanels.join("|"), [activePanels]);
   const openPanelSet = useMemo(() => new Set(consideredPanelIds), [consideredPanelIds]);
 
   const needsTensorboard = useMemo(
@@ -128,6 +129,8 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
     () => showSeed && activePanelSet.has(panelDefinitions.diagnostics.id),
     [showSeed, activePanelSet],
   );
+
+  const selectedTagsKey = useMemo(() => selectedTags.join("|"), [selectedTags]);
 
   const needsMetricsData = useMemo(
     () => consideredPanelIds.some((panel) => METRIC_PANELS.has(panel)),
@@ -165,29 +168,41 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
   const { seedAgg } = useSeedAggregates({ runId, tags, needsSeedAggregates });
 
   useEffect(() => {
-    if (!runId || !autoRefresh) return;
-    const timer = setInterval(() => {
-      void reload(true);
-    }, 8000);
-    return () => clearInterval(timer);
-  }, [runId, autoRefresh, reload]);
+    if (!runId || !activePanels.length) return;
 
-  useEffect(() => {
-    if (!runId) return;
-    void reload();
-  }, [runId, reload]);
+    const shouldFetch = needsTensorboard || needsTags || needsGradients;
+    if (!shouldFetch) return;
 
-  useEffect(() => {
-    if (!runId) return;
-    if (!needsTensorboard && !needsTags && !needsGradients) return;
-    void reload();
-  }, [runId, needsTensorboard, needsTags, needsGradients, reload]);
+    let cancelled = false;
+    const invoke = (fromTimer: boolean) => {
+      if (cancelled) return;
+      void reload(fromTimer);
+    };
 
-  useEffect(() => {
-    if (!runId || activePanels.length === 0) return;
-    void reload();
-  }, [runId, activePanels, reload]);
+    invoke(false);
 
+    let timer: ReturnType<typeof setInterval> | null = null;
+    if (autoRefresh) {
+      timer = setInterval(() => {
+        invoke(true);
+      }, 8000);
+    }
+
+    return () => {
+      cancelled = true;
+      if (timer) clearInterval(timer);
+    };
+  }, [
+    runId,
+    autoRefresh,
+    needsTensorboard,
+    needsTags,
+    needsGradients,
+    activePanelsKey,
+    selectedTagsKey,
+    activePanels.length,
+    reload,
+  ]);
   const gradientSurface = useMemo(() => {
     if (!gradMatrix?.layers?.length || !gradMatrix?.steps?.length) return null;
     const rows = gradMatrix.steps.length;

--- a/frontend/src/components/Stockbot/lib/runs.ts
+++ b/frontend/src/components/Stockbot/lib/runs.ts
@@ -4,6 +4,11 @@ const RECENT_KEY = "stockbot_recent_runs";
 const SAVED_KEY = "stockbot_saved_runs";
 const MAX_RECENT = 50;
 const MAX_SAVED = 5;
+const RUN_CACHE_TTL_MS = 15_000;
+
+let runsCache: RunSummary[] | null = null;
+let runsCacheTimestamp = 0;
+let runsPromise: Promise<RunSummary[]> | null = null;
 
 type StoreKey = typeof RECENT_KEY | typeof SAVED_KEY;
 
@@ -52,4 +57,56 @@ export function toggleSavedRun(run: RunSummary): RunSummary[] {
   const exists = current.find((r) => r.id === run.id);
   const next = exists ? current.filter((r) => r.id !== run.id) : [run, ...current];
   return saveSavedRuns(next);
+}
+
+export function getRunsCacheSnapshot(): RunSummary[] | null {
+  return runsCache;
+}
+
+export function primeRunsCache(runs: RunSummary[]): RunSummary[] {
+  runsCache = [...runs];
+  runsCacheTimestamp = Date.now();
+  return runsCache;
+}
+
+export function clearRunsCache(): void {
+  runsCache = null;
+  runsCacheTimestamp = 0;
+  runsPromise = null;
+}
+
+export async function fetchRunsCached(
+  fetcher: () => Promise<RunSummary[]>,
+  options: { force?: boolean; ttlMs?: number } = {},
+): Promise<RunSummary[]> {
+  const { force = false, ttlMs = RUN_CACHE_TTL_MS } = options;
+  const now = Date.now();
+
+  if (!force && runsCache && now - runsCacheTimestamp < ttlMs) {
+    return runsCache;
+  }
+  if (!force && runsPromise) {
+    return runsPromise;
+  }
+
+  const request = (async () => {
+    const result = await fetcher();
+    primeRunsCache(result);
+    return runsCache ?? [];
+  })();
+
+  if (!force) {
+    runsPromise = request;
+  }
+
+  try {
+    return await request;
+  } finally {
+    if (runsPromise === request) {
+      runsPromise = null;
+    }
+    if (force) {
+      runsCacheTimestamp = Date.now();
+    }
+  }
 }


### PR DESCRIPTION
Stabilized tensorboard polling by caching mutable state in refs, adding a timer throttle, and reusing a single reload callback so repeated renders no longer spam the API (frontend/src/components/Stockbot/TrainingResults/hooks/useTensorboardData.ts:74). Replaced the four overlapping reload effects with one orchestrated effect that keys off panel activity, auto-refresh, and tag changes to ensure only one fetch cycle runs at a time (frontend/src/components/Stockbot/TrainingResults/index.tsx:170). Introduced a shared in-memory cache for run metadata and wired both useRunSelection and useSeedAggregates through it so /stockbot/runs is fetched once and reused across consumers