### PR TITLE
Improve training results layout and run selection

### DIFF
--- a/frontend/src/app/stockbot/page.tsx
+++ b/frontend/src/app/stockbot/page.tsx
@@ -19,9 +19,9 @@ export default function Page() {
   const [trainingRunId, setTrainingRunId] = useState<string | null>(null);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="flex min-h-screen flex-col gap-6 p-6">
       <TooltipProvider delayDuration={80}>
-        <Tabs value={tab} onValueChange={setTab} className="space-y-6">
+        <Tabs value={tab} onValueChange={setTab} className="flex flex-1 flex-col gap-6">
         <TabsList className="w-full grid grid-cols-8 gap-2">
           <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
           <TabsTrigger value="new-training">New Training</TabsTrigger>
@@ -77,7 +77,7 @@ export default function Page() {
           <RunDetail />
         </TabsContent>
 
-        <TabsContent value="training-results">
+        <TabsContent value="training-results" className="flex flex-1 flex-col overflow-hidden">
           <TrainingResults initialRunId={trainingRunId || undefined} />
         </TabsContent>
 

--- a/frontend/src/components/Stockbot/TrainingResults/hooks/useRunSelection.ts
+++ b/frontend/src/components/Stockbot/TrainingResults/hooks/useRunSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import api from "@/api/client";
 import { deleteRun } from "@/api/stockbot";
@@ -13,12 +13,17 @@ import {
 export function useRunSelection(initialRunId?: string) {
   const [runs, setRuns] = useState<RunSummary[]>(() => getRunsCacheSnapshot() ?? []);
   const [runId, setRunId] = useState<string>(initialRunId || "");
+  const previousInitialRunId = useRef<string | undefined>(initialRunId);
 
   useEffect(() => {
-    if (initialRunId && initialRunId !== runId) {
-      setRunId(initialRunId);
+    if (!initialRunId) {
+      previousInitialRunId.current = undefined;
+      return;
     }
-  }, [initialRunId, runId]);
+    if (previousInitialRunId.current === initialRunId) return;
+    previousInitialRunId.current = initialRunId;
+    setRunId(initialRunId);
+  }, [initialRunId]);
 
   const fetchRuns = useCallback(
     async (options?: { force?: boolean }) => {

--- a/frontend/src/components/Stockbot/TrainingResults/index.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/index.tsx
@@ -458,7 +458,7 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
 
   const dockviewProps = useMemo<IDockviewReactProps>(
     () => ({
-      className: "dockview-theme-abyss h-full w-full border bg-card/60 shadow-sm",
+      className: "dockview-theme-abyss h-full w-full",
       components: dockComponents,
       disableFloatingGroups: false,
       dndEdges: dockviewRootDndEdges,
@@ -472,7 +472,7 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
 
   return (
     <>
-      <div className="space-y-4">
+      <div className="flex flex-1 flex-col gap-4">
         <ControlPanel
           runId={runId}
           runs={runs}
@@ -493,7 +493,7 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
           tags={tags}
         />
 
-        <div className="w-full h-[70vh] min-h-[520px] max-h-[820px]">
+        <div className="flex min-h-[560px] flex-1 overflow-hidden rounded-xl border bg-card/60 shadow-sm">
           <DockviewReact {...dockviewProps} />
         </div>
       </div>

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/ControlPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/ControlPanel.tsx
@@ -100,7 +100,7 @@ export function ControlPanel({
           <TooltipLabel className="text-xs" tooltip="Select a training run to inspect">
             Run
           </TooltipLabel>
-          <Select value={runId} onValueChange={onRunChange} disabled={!runs.length}>
+          <Select value={runId || undefined} onValueChange={onRunChange} disabled={!runs.length}>
             <SelectTrigger className="w-full">
               <SelectValue placeholder={runPlaceholder} />
             </SelectTrigger>


### PR DESCRIPTION
## Summary
- stretch the StockBot training results tab to occupy the available viewport height
- expand the dock view canvas container and remove redundant styling from the Dockview component
- ensure run selections persist by only syncing the initial run id when it actually changes

## Testing
- npm run lint *(fails: next binary missing before install)*
- npm install *(fails: npm registry returned 403 for react package)*

------
https://chatgpt.com/codex/tasks/task_e_68d493cb3fa88331ae4a32ea60fb363a