### PR TITLE
Stabilize training results dock sizing and guard panel creation

### DIFF
--- a/frontend/src/app/stockbot/page.tsx
+++ b/frontend/src/app/stockbot/page.tsx
@@ -19,79 +19,86 @@ export default function Page() {
   const [trainingRunId, setTrainingRunId] = useState<string | null>(null);
 
   return (
-    <div className="p-6 space-y-6">
+    <div className="flex min-h-screen flex-col gap-6 p-6">
       <TooltipProvider delayDuration={80}>
-        <Tabs value={tab} onValueChange={setTab} className="space-y-6">
-        <TabsList className="w-full grid grid-cols-8 gap-2">
-          <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
-          <TabsTrigger value="new-training">New Training</TabsTrigger>
-          <TabsTrigger value="new-backtest">New Backtest</TabsTrigger>
-          <TabsTrigger value="run-detail">Run Detail</TabsTrigger>
-          <TabsTrigger value="training-results">Training Results</TabsTrigger>
-          <TabsTrigger value="compare">Compare Runs</TabsTrigger>
-          <TabsTrigger value="trade">Live Trading</TabsTrigger>
-          <TabsTrigger value="settings">Settings</TabsTrigger>
-        </TabsList>
+        <Tabs
+          value={tab}
+          onValueChange={setTab}
+          className="flex flex-1 min-h-0 flex-col gap-6"
+        >
+          <TabsList className="grid w-full grid-cols-8 gap-2">
+            <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+            <TabsTrigger value="new-training">New Training</TabsTrigger>
+            <TabsTrigger value="new-backtest">New Backtest</TabsTrigger>
+            <TabsTrigger value="run-detail">Run Detail</TabsTrigger>
+            <TabsTrigger value="training-results">Training Results</TabsTrigger>
+            <TabsTrigger value="compare">Compare Runs</TabsTrigger>
+            <TabsTrigger value="trade">Live Trading</TabsTrigger>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
+          </TabsList>
 
-        <TabsContent value="dashboard">
-          <Dashboard
-            onNewTraining={() => setTab("new-training")}
-            onNewBacktest={() => {
-              setBacktestRunId(null);
-              setTab("new-backtest");
-            }}
-            onOpenRun={(_id) => {
-              setTrainingRunId(_id);
-              setTab("training-results");
-            }}
-            onBacktestRun={(id) => {
-              setBacktestRunId(id);
-              setTab("new-backtest");
-            }}
-          />
-        </TabsContent>
+          <TabsContent value="dashboard">
+            <Dashboard
+              onNewTraining={() => setTab("new-training")}
+              onNewBacktest={() => {
+                setBacktestRunId(null);
+                setTab("new-backtest");
+              }}
+              onOpenRun={(_id) => {
+                setTrainingRunId(_id);
+                setTab("training-results");
+              }}
+              onBacktestRun={(id) => {
+                setBacktestRunId(id);
+                setTab("new-backtest");
+              }}
+            />
+          </TabsContent>
 
-        <TabsContent value="new-training">
-          <NewTraining
-            // Keep the callback for UX flow; no longer pass to RunDetail
-            onJobCreated={(_id) => {
-              setTrainingRunId(_id);
-              setTab("training-results");
-            }}
-            onCancel={() => setTab("dashboard")}
-          />
-        </TabsContent>
+          <TabsContent value="new-training">
+            <NewTraining
+              // Keep the callback for UX flow; no longer pass to RunDetail
+              onJobCreated={(_id) => {
+                setTrainingRunId(_id);
+                setTab("training-results");
+              }}
+              onCancel={() => setTab("dashboard")}
+            />
+          </TabsContent>
 
-        <TabsContent value="new-backtest">
-          <NewBacktest
-            runId={backtestRunId ?? undefined}
-            onJobCreated={(_id) => {
-              setTab("run-detail");
-            }}
-            onCancel={() => setTab("dashboard")}
-          />
-        </TabsContent>
+          <TabsContent value="new-backtest">
+            <NewBacktest
+              runId={backtestRunId ?? undefined}
+              onJobCreated={(_id) => {
+                setTab("run-detail");
+              }}
+              onCancel={() => setTab("dashboard")}
+            />
+          </TabsContent>
 
-        <TabsContent value="run-detail">
-          {/* RunDetail is now upload-only and takes no props */}
-          <RunDetail />
-        </TabsContent>
+          <TabsContent value="run-detail">
+            {/* RunDetail is now upload-only and takes no props */}
+            <RunDetail />
+          </TabsContent>
 
-        <TabsContent value="training-results">
-          <TrainingResults initialRunId={trainingRunId || undefined} />
-        </TabsContent>
+          <TabsContent
+            value="training-results"
+            className="flex min-h-0 flex-1 flex-col overflow-hidden"
+          >
+            <TrainingResults initialRunId={trainingRunId || undefined} />
+          </TabsContent>
 
-        <TabsContent value="compare">
-          <CompareRuns />
-        </TabsContent>
+          <TabsContent value="compare">
+            <CompareRuns />
+          </TabsContent>
 
-        <TabsContent value="trade">
-          <LiveTrading />
-        </TabsContent>
+          <TabsContent value="trade">
+            <LiveTrading />
+          </TabsContent>
 
-        <TabsContent value="settings">
-          <Settings />
-        </TabsContent>
+          <TabsContent value="settings">
+            <Settings />
+          </TabsContent>
         </Tabs>
       </TooltipProvider>
     </div>

--- a/frontend/src/components/Stockbot/TrainingResults/hooks/useDockviewManager.ts
+++ b/frontend/src/components/Stockbot/TrainingResults/hooks/useDockviewManager.ts
@@ -379,8 +379,9 @@ export function useDockviewManager(): DockviewManager {
       const panel = panelDefinitions[panelKey];
       if (!panel) return;
 
-      if (openPanels.includes(panel.id)) {
-        setPanelActive(api.getPanel(panel.id));
+      const existing = api.getPanel(panel.id);
+      if (existing) {
+        setPanelActive(existing);
         return;
       }
 
@@ -397,7 +398,7 @@ export function useDockviewManager(): DockviewManager {
       } catch {}
       setCurrentLayout("custom");
     },
-    [openPanels, setPanelActive, updateOpenPanels, commitVisiblePanels],
+    [setPanelActive, updateOpenPanels, commitVisiblePanels],
   );
 
   const focusPanel = useCallback(

--- a/frontend/src/components/Stockbot/TrainingResults/hooks/useRunSelection.ts
+++ b/frontend/src/components/Stockbot/TrainingResults/hooks/useRunSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import api from "@/api/client";
 import { deleteRun } from "@/api/stockbot";
@@ -13,12 +13,17 @@ import {
 export function useRunSelection(initialRunId?: string) {
   const [runs, setRuns] = useState<RunSummary[]>(() => getRunsCacheSnapshot() ?? []);
   const [runId, setRunId] = useState<string>(initialRunId || "");
+  const previousInitialRunId = useRef<string | undefined>(initialRunId);
 
   useEffect(() => {
-    if (initialRunId && initialRunId !== runId) {
-      setRunId(initialRunId);
+    if (!initialRunId) {
+      previousInitialRunId.current = undefined;
+      return;
     }
-  }, [initialRunId, runId]);
+    if (previousInitialRunId.current === initialRunId) return;
+    previousInitialRunId.current = initialRunId;
+    setRunId(initialRunId);
+  }, [initialRunId]);
 
   const fetchRuns = useCallback(
     async (options?: { force?: boolean }) => {

--- a/frontend/src/components/Stockbot/TrainingResults/index.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/index.tsx
@@ -458,7 +458,7 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
 
   const dockviewProps = useMemo<IDockviewReactProps>(
     () => ({
-      className: "dockview-theme-abyss h-full w-full border bg-card/60 shadow-sm",
+      className: "dockview-theme-abyss h-full w-full",
       components: dockComponents,
       disableFloatingGroups: false,
       dndEdges: dockviewRootDndEdges,
@@ -472,7 +472,7 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
 
   return (
     <>
-      <div className="space-y-4">
+      <div className="flex min-h-0 flex-1 flex-col gap-4">
         <ControlPanel
           runId={runId}
           runs={runs}
@@ -493,7 +493,10 @@ export default function TrainingResults({ initialRunId }: TrainingResultsProps) 
           tags={tags}
         />
 
-        <div className="w-full h-[70vh] min-h-[520px] max-h-[820px]">
+        <div
+          className="flex-1 overflow-hidden rounded-xl border bg-card/60 shadow-sm"
+          style={{ height: "clamp(620px, calc(100vh - 320px), 960px)" }}
+        >
           <DockviewReact {...dockviewProps} />
         </div>
       </div>

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/ControlPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/ControlPanel.tsx
@@ -100,7 +100,7 @@ export function ControlPanel({
           <TooltipLabel className="text-xs" tooltip="Select a training run to inspect">
             Run
           </TooltipLabel>
-          <Select value={runId} onValueChange={onRunChange} disabled={!runs.length}>
+          <Select value={runId || undefined} onValueChange={onRunChange} disabled={!runs.length}>
             <SelectTrigger className="w-full">
               <SelectValue placeholder={runPlaceholder} />
             </SelectTrigger>


### PR DESCRIPTION
## Summary
- let the StockBot tabs layout stretch and give the training results tab a min-h-0 flex container so the dock can consume the viewport height
- clamp the dock container height to fill most of the screen while keeping the existing card chrome
- guard Dockview panel creation by focusing any existing panel instead of trying to add a duplicate id

## Testing
- npm install *(fails: registry returns 403 for react)*
- npm run lint *(fails: `next` binary missing before dependencies install)*

------
https://chatgpt.com/codex/tasks/task_e_68d493cb3fa88331ae4a32ea60fb363a