### PR TITLE
Improve training results responsiveness with container queries

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -177,6 +177,123 @@
 
   .accent-swatch-emerald { background-color: hsl(142 76% 34%); }
   .dark .accent-swatch-emerald { background-color: hsl(142 76% 36%); }
+
+  .training-panel-content {
+    container-type: inline-size;
+  }
+
+  .training-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .training-grid--cols-2,
+  .training-grid--cols-3,
+  .training-grid--overview {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  @container (min-width: 32rem) {
+    .training-grid--cols-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @container (min-width: 48rem) {
+    .training-grid--overview {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .training-grid--cols-3 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @container (min-width: 60rem) {
+    .training-grid--cols-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  @container (min-width: 70rem) {
+    .training-grid--overview {
+      grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    }
+  }
+
+  .training-chart {
+    position: relative;
+    width: 100%;
+    min-height: 12rem;
+    aspect-ratio: 4 / 3;
+  }
+
+  .training-chart--xs {
+    min-height: 7rem;
+  }
+
+  .training-chart--sm {
+    min-height: 10rem;
+  }
+
+  .training-chart--md {
+    min-height: 14rem;
+  }
+
+  .training-chart--lg {
+    min-height: 16rem;
+  }
+
+  .training-chart--xl {
+    min-height: 18rem;
+  }
+
+  @container (max-width: 28rem) {
+    .training-chart {
+      aspect-ratio: 1;
+      min-height: 10rem;
+    }
+  }
+
+  @container (min-width: 40rem) {
+    .training-chart {
+      aspect-ratio: 16 / 9;
+    }
+
+    .training-chart--md {
+      min-height: 15rem;
+    }
+
+    .training-chart--lg {
+      min-height: 18rem;
+    }
+
+    .training-chart--xl {
+      min-height: 20rem;
+    }
+  }
+
+  @container (min-width: 64rem) {
+    .training-chart--xs {
+      min-height: 8rem;
+    }
+
+    .training-chart--sm {
+      min-height: 12rem;
+    }
+
+    .training-chart--md {
+      min-height: 16rem;
+    }
+
+    .training-chart--lg {
+      min-height: 20rem;
+    }
+
+    .training-chart--xl {
+      min-height: 22rem;
+    }
+  }
 }
 
 /* --- Custom Theme Animations & Background --- */

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/ActionsHistogramSection.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/ActionsHistogramSection.tsx
@@ -61,7 +61,7 @@ export function ActionsHistogramSection({ runId, tags }: ActionsHistogramSection
           {loading ? "Loading…" : "Refresh"}
         </Button>
       </div>
-      <div className="h-64">
+      <div className="training-chart training-chart--lg">
         <ResponsiveContainer width="100%" height="100%">
           <BarChart data={data}>
             <CartesianGrid strokeDasharray="3 3" />

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/ChartCard.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/ChartCard.tsx
@@ -78,7 +78,7 @@ export function ChartCard({ title, tag, series, timeRange, color }: ChartCardPro
       <TooltipLabel className="font-semibold" tooltip={tip || title}>
         {title}
       </TooltipLabel>
-      <div className="h-56">
+      <div className="training-chart training-chart--md">
         <LineChart
           data={data}
           config={chartConfig}

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/DiagnosticsPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/DiagnosticsPanel.tsx
@@ -71,12 +71,12 @@ export function DiagnosticsPanel({
         </div>
         {showOptim && (
           <>
-            <div className="grid gap-6 xl:grid-cols-3 md:grid-cols-2">
+            <div className="training-grid gap-6 training-grid--cols-3">
               <ChartCard title="Value Loss" tag={valueLossTag} series={series} timeRange={timeRange} />
               <ChartCard title="Policy Loss" tag={policyLossTag} series={series} timeRange={timeRange} />
               <ChartCard title="Entropy" tag={entropyTag} series={series} timeRange={timeRange} />
             </div>
-            <div className="grid gap-6 xl:grid-cols-3 md:grid-cols-2">
+            <div className="training-grid gap-6 training-grid--cols-3">
               <ChartCard title="Learning Rate" tag={lrTag} series={series} timeRange={timeRange} />
               <ChartCard title="Clip Fraction" tag={clipFracTag} series={series} timeRange={timeRange} />
               <ChartCard title="Approx KL" tag={klTag} series={series} timeRange={timeRange} />
@@ -96,7 +96,7 @@ export function DiagnosticsPanel({
           </label>
         </div>
         {showTiming && (
-          <div className="grid gap-6 md:grid-cols-2">
+          <div className="training-grid gap-6 training-grid--cols-2">
             <ChartCard title="FPS" tag={fpsTag} series={series} timeRange={timeRange} />
           </div>
         )}

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/GradientsSection.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/GradientsSection.tsx
@@ -131,7 +131,7 @@ export function GradientsSection({
       </div>
       {showGrads && (
         <>
-          <div className="grid gap-6 lg:grid-cols-2">
+          <div className="training-grid gap-6 training-grid--cols-2">
             <ChartCard title="Gradient Norm" tag={gradTag} color="#ef4444" series={series} timeRange={timeRange} />
             {showHeatmap && gradMatrix && (
               <Card className="p-4 space-y-2">

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/MonitorPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/MonitorPanel.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import RunMonitor from "../../run-monitor";
+import { PanelBody } from "./PanelBody";
 
 export type MonitorPanelProps = {
   runId: string;
@@ -7,21 +8,14 @@ export type MonitorPanelProps = {
 
 export function MonitorPanel({ runId }: MonitorPanelProps) {
   return (
-    <div
-      className="h-full overflow-hidden bg-background"
-      data-lenis-prevent
-      data-lenis-prevent-wheel
-      data-lenis-prevent-touch
-    >
-      <div className="h-full overflow-auto p-4 space-y-4">
-        {runId ? (
-          <RunMonitor runId={runId} />
-        ) : (
-          <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-            Select a run to open the live monitor.
-          </div>
-        )}
-      </div>
-    </div>
+    <PanelBody>
+      {runId ? (
+        <RunMonitor runId={runId} />
+      ) : (
+        <div className="flex h-full min-h-[200px] items-center justify-center text-sm text-muted-foreground">
+          Select a run to open the live monitor.
+        </div>
+      )}
+    </PanelBody>
   );
 }

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/OverviewPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/OverviewPanel.tsx
@@ -122,7 +122,7 @@ export function OverviewPanel({
 
   return (
     <PanelBody>
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <div className="training-grid gap-4 training-grid--overview">
         <div className="space-y-4">
           <Card className="space-y-3 p-4">
             <div className="flex items-center justify-between gap-2">
@@ -135,7 +135,7 @@ export function OverviewPanel({
                 </Badge>
               )}
             </div>
-            <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
+            <div className="training-grid gap-3 text-sm training-grid--cols-3">
               {summary.map((item) => (
                 <div key={item.label} className="flex flex-col">
                   <span className="text-xs uppercase text-muted-foreground">{item.label}</span>
@@ -153,7 +153,7 @@ export function OverviewPanel({
               Equity vs Drawdown
             </TooltipLabel>
             {chartData.length ? (
-              <div className="h-64 w-full">
+              <div className="training-chart training-chart--lg">
                 <ResponsiveContainer width="100%" height="100%">
                   <ComposedChart data={chartData} margin={{ top: 5, right: 20, bottom: 0, left: 0 }}>
                     <CartesianGrid strokeDasharray="3 3" />
@@ -199,13 +199,13 @@ export function OverviewPanel({
             )}
           </Card>
 
-          <div className="grid gap-4 lg:grid-cols-2">
+          <div className="training-grid gap-4 training-grid--cols-2">
             <Card className="space-y-2 p-4">
               <TooltipLabel className="font-semibold" tooltip="Rolling Sharpe computed from rolling_metrics.csv if available.">
                 Rolling Sharpe
               </TooltipLabel>
               {rolling.sharpe.length ? (
-                <div className="h-28 w-full">
+                <div className="training-chart training-chart--xs">
                   <ResponsiveContainer width="100%" height="100%">
                     <LineChart data={rolling.sharpe} margin={{ top: 4, right: 6, left: 0, bottom: 0 }}>
                       <Line
@@ -228,7 +228,7 @@ export function OverviewPanel({
                 Rolling Volatility
               </TooltipLabel>
               {rolling.volatility.length ? (
-                <div className="h-28 w-full">
+                <div className="training-chart training-chart--xs">
                   <ResponsiveContainer width="100%" height="100%">
                     <LineChart data={rolling.volatility} margin={{ top: 4, right: 6, left: 0, bottom: 0 }}>
                       <Line
@@ -267,7 +267,7 @@ export function OverviewPanel({
               </label>
             </div>
             {showRollout && rewardTag ? (
-              <div className="grid gap-4 lg:grid-cols-2">
+              <div className="training-grid gap-4 training-grid--cols-2">
                 <ChartCard title="Reward (train/eval)" tag={rewardTag} color="#3b82f6" series={series} timeRange={timeRange} />
                 <ChartCard title="Episode Length (mean)" tag={epLenTag} series={series} timeRange={timeRange} />
               </div>

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/PanelBody.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/PanelBody.tsx
@@ -8,7 +8,9 @@ export function PanelBody({ children }: { children: React.ReactNode }) {
       data-lenis-prevent-wheel
       data-lenis-prevent-touch
     >
-      <div className="h-full overflow-auto space-y-4 p-4">{children}</div>
+      <div className="h-full overflow-auto">
+        <div className="training-panel-content space-y-4 p-4">{children}</div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/PerformancePanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/PerformancePanel.tsx
@@ -128,7 +128,7 @@ export function PerformancePanel({
 
   return (
     <PanelBody>
-      <div className="grid gap-4 xl:grid-cols-2">
+      <div className="training-grid gap-4 training-grid--cols-2">
         <Card className="p-4 space-y-3">
           <TooltipLabel
             className="font-semibold"
@@ -137,7 +137,7 @@ export function PerformancePanel({
             Equity Curve
           </TooltipLabel>
           {equitySeries.length ? (
-            <div className="h-64">
+            <div className="training-chart training-chart--lg">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={equitySeries}>
                   <CartesianGrid strokeDasharray="3 3" />
@@ -187,7 +187,7 @@ export function PerformancePanel({
             Cumulative PnL vs Baseline
           </TooltipLabel>
           {pnlSeries.length ? (
-            <div className="h-64">
+            <div className="training-chart training-chart--lg">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={pnlSeries}>
                   <CartesianGrid strokeDasharray="3 3" />
@@ -219,7 +219,7 @@ export function PerformancePanel({
             Rolling Risk-Adjusted Returns
           </TooltipLabel>
           {rollingSeries.length ? (
-            <div className="h-64">
+            <div className="training-chart training-chart--lg">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={rollingSeries}>
                   <CartesianGrid strokeDasharray="3 3" />
@@ -242,7 +242,7 @@ export function PerformancePanel({
             Return Distribution
           </TooltipLabel>
           {returnHistogram.length ? (
-            <div className="h-64">
+            <div className="training-chart training-chart--lg">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={returnHistogram}>
                   <CartesianGrid strokeDasharray="3 3" />

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/RiskPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/RiskPanel.tsx
@@ -133,14 +133,14 @@ export function RiskPanel({ leverage, riskStats, exposures, rolling, drawdown }:
 
   return (
     <PanelBody>
-      <div className="grid gap-4 xl:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+      <div className="training-grid gap-4 training-grid--overview">
         <div className="space-y-4">
           <Card className="space-y-3 p-4">
             <TooltipLabel className="font-semibold" tooltip="Turnover and leverage trajectories from equity.csv.">
               Leverage & Turnover
             </TooltipLabel>
             {leverageSeries.length ? (
-              <div className="h-64">
+              <div className="training-chart training-chart--lg">
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart data={leverageSeries}>
                     <CartesianGrid strokeDasharray="3 3" />
@@ -164,7 +164,7 @@ export function RiskPanel({ leverage, riskStats, exposures, rolling, drawdown }:
               Volatility & Drawdown
             </TooltipLabel>
             {volDrawdownSeries.length ? (
-              <div className="h-60">
+              <div className="training-chart training-chart--lg">
                 <ResponsiveContainer width="100%" height="100%">
                   <AreaChart data={volDrawdownSeries}>
                     <CartesianGrid strokeDasharray="3 3" />
@@ -212,7 +212,7 @@ export function RiskPanel({ leverage, riskStats, exposures, rolling, drawdown }:
             <TooltipLabel className="font-semibold" tooltip="Key realised risk statistics computed from the run data.">
               Risk Snapshot
             </TooltipLabel>
-            <div className="grid gap-2 sm:grid-cols-2 text-sm">
+            <div className="training-grid gap-2 text-sm training-grid--cols-2">
               {riskCards.map((card) => (
                 <div key={card.label} className="flex flex-col gap-1">
                   <Badge variant="outline" className={`${card.tone} text-[11px] w-fit`}>{card.label}</Badge>

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/ScalarsPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/ScalarsPanel.tsx
@@ -81,7 +81,7 @@ export function ScalarsPanel({
                 Clear
               </button>
             </div>
-            <div className="grid gap-4 lg:grid-cols-2">
+            <div className="training-grid gap-4 training-grid--cols-2">
               {selectedTags
                 .filter((tag) => visibleSelected[tag] !== false)
                 .map((tag, index) => (

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/SeedAggregateSection.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/SeedAggregateSection.tsx
@@ -79,7 +79,7 @@ export function SeedAggregateSection({ showSeed, onToggle, seedAgg }: SeedAggreg
           )}
 
           {hasEntropy && seedAgg.entropy && (
-            <div className="h-56">
+            <div className="training-chart training-chart--md">
               <LineChart data={seedAgg.entropy} config={seedEntropyConfig} height="100%">
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="step" tickFormatter={fmtStep} />
@@ -100,7 +100,7 @@ export function SeedAggregateSection({ showSeed, onToggle, seedAgg }: SeedAggreg
           )}
 
           {hasActions && seedAgg.actionHist && (
-            <div className="h-56">
+            <div className="training-chart training-chart--md">
               <ChartContainer config={histogramConfig} className="h-full">
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={seedAgg.actionHist}>

--- a/frontend/src/components/Stockbot/TrainingResults/new-training/TradesPanel.tsx
+++ b/frontend/src/components/Stockbot/TrainingResults/new-training/TradesPanel.tsx
@@ -40,7 +40,7 @@ export function TradesPanel({
 }: TradesPanelProps) {
   return (
     <PanelBody>
-      <div className="grid gap-4 xl:grid-cols-2">
+      <div className="training-grid gap-4 training-grid--cols-2">
         <Card className="space-y-3 p-4">
           <div className="flex items-center justify-between gap-2">
             <TooltipLabel className="font-semibold" tooltip="Completed trades per day or episode step.">
@@ -51,7 +51,7 @@ export function TradesPanel({
             </div>
           </div>
           {tradeAnalytics.frequency.length ? (
-            <div className="h-60">
+            <div className="training-chart training-chart--lg">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={tradeAnalytics.frequency}>
                   <CartesianGrid strokeDasharray="3 3" />
@@ -72,7 +72,7 @@ export function TradesPanel({
             Avg Position Size
           </TooltipLabel>
           {tradeAnalytics.averagePosition.length ? (
-            <div className="h-60">
+            <div className="training-chart training-chart--lg">
               <ResponsiveContainer width="100%" height="100%">
                 <LineChart data={tradeAnalytics.averagePosition}>
                   <CartesianGrid strokeDasharray="3 3" />
@@ -93,7 +93,7 @@ export function TradesPanel({
             Holding Periods
           </TooltipLabel>
           {tradeAnalytics.holdingBuckets.length ? (
-            <div className="h-56">
+            <div className="training-chart training-chart--md">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={tradeAnalytics.holdingBuckets}>
                   <CartesianGrid strokeDasharray="3 3" />
@@ -114,7 +114,7 @@ export function TradesPanel({
             Outcomes & Contribution
           </TooltipLabel>
           {tradeAnalytics.winLoss.length ? (
-            <div className="h-56">
+            <div className="training-chart training-chart--md">
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart data={tradeAnalytics.winLoss}>
                   <CartesianGrid strokeDasharray="3 3" />
@@ -131,7 +131,7 @@ export function TradesPanel({
           {tradeAnalytics.symbolContribution.length ? (
             <div>
               <div className="text-xs font-semibold text-muted-foreground mb-2">Top Contributors</div>
-              <div className="h-48">
+              <div className="training-chart training-chart--sm">
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart data={tradeAnalytics.symbolContribution} layout="vertical">
                     <CartesianGrid strokeDasharray="3 3" />


### PR DESCRIPTION
## Summary
- add container-query driven layout utilities for the training results dashboard
- update each training results panel to use responsive grids and chart wrappers that adapt to their panel width
- route the monitor panel through the shared PanelBody so it inherits the new responsive behavior

## Testing
- npm run lint *(fails: next binary missing; npm install blocked by registry access)*

------
https://chatgpt.com/codex/tasks/task_e_68d49ac85498833192f9447c180443f0