### PR TITLE
Pipe insights through Jarvis LLM

### DIFF
--- a/stockbot/api/controllers/insights_controller.py
+++ b/stockbot/api/controllers/insights_controller.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+import json
+import logging
 from statistics import fmean
 from typing import Any, Dict, Iterable, List
 
 from pydantic import BaseModel
 
 from providers.provider_manager import ProviderManager
+
+try:
+    from jarvis.jarvis_factory import jarvis_service_instance
+
+    _OLLAMA_AGENT = getattr(jarvis_service_instance, "agent", None)
+except Exception:  # pragma: no cover - defensive import guard
+    _OLLAMA_AGENT = None
+
+
+logger = logging.getLogger(__name__)
 
 
 class InsightsRequest(BaseModel):
@@ -18,6 +30,14 @@ def _to_float(value: Any) -> float:
         return float(value)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _format_currency(value: float) -> str:
+    return f"${value:,.2f}"
+
+
+def _format_percent(value: float) -> str:
+    return f"{value:.1%}"
 
 
 def _best(items: Iterable[Dict[str, Any]], key: str, reverse: bool = True) -> Dict[str, Any] | None:
@@ -82,48 +102,67 @@ def generate_insights(req: InsightsRequest) -> dict:
     avg_turnover = _average_turnover(transactions)
     concentration = _concentration(open_positions)
 
-    insights: List[str] = []
     bot_name = "Jarvis"
 
-    summary_parts = [
-        f"Account equity stands at ${equity:,.2f}",
-        f"cash reserves ${cash:,.2f} ({cash_ratio:.0%} of equity)",
+    turnover_ratio = (avg_turnover / equity) if equity else 0.0
+
+    fallback_insights: List[str] = []
+    overview_parts = [
+        f"Account equity stands at {_format_currency(equity)}" if equity else "Account equity is unavailable",
+        f"cash reserves {_format_currency(cash)} ({_format_percent(cash_ratio)} of equity)" if equity else f"cash on hand {_format_currency(cash)}",
     ]
     if open_positions:
-        summary_parts.append(
-            f"with {len(open_positions)} open positions representing ${invested_value:,.2f} in exposure"
+        exposure_pct = (invested_value / equity) if equity else 0.0
+        overview_parts.append(
+            f"{len(open_positions)} open positions with {_format_currency(invested_value)} deployed ({_format_percent(exposure_pct)} of equity)"
         )
     if buying_power:
-        summary_parts.append(f"and available buying power of ${buying_power:,.2f}")
+        overview_parts.append(f"available buying power of {_format_currency(buying_power)}")
     if day_pl:
-        summary_parts.append(f"today's P/L is ${day_pl:,.2f}")
-    insights.append("; ".join(summary_parts) + ".")
+        overview_parts.append(f"today's P/L at {_format_currency(day_pl)}")
+    if turnover_ratio:
+        overview_parts.append(f"average ticket size running at {_format_percent(turnover_ratio)} of equity per trade")
+    fallback_insights.append("Overview: " + "; ".join(overview_parts) + ".")
+
+    concentration_text = (
+        f"Current risk budget shows single-name concentration around {_format_percent(concentration)}, which is {'elevated' if concentration > 0.25 else 'within guardrails'}."
+        if open_positions
+        else "No active positions at the moment to judge concentration."
+    )
 
     if top_winner and _to_float(top_winner.get("dayPL")) > 0:
         sym = top_winner.get("symbol", "top holding")
         gain = _to_float(top_winner.get("dayPL"))
         total_pl = _to_float(top_winner.get("totalPL"))
-        insights.append(
-            f"✅ Strength: {sym} contributed ${gain:,.2f} today and is ${total_pl:,.2f} ahead overall, supporting the strategy's signals."
+        fallback_insights.append(
+            "✅ Strength: "
+            + f"{sym} contributed {_format_currency(gain)} today and sits {_format_currency(total_pl)} ahead overall, confirming the bot's entry logic."
         )
     else:
-        insights.append("✅ Strength: Portfolio is defensively positioned with limited downside captured in today's results.")
+        fallback_insights.append(
+            "✅ Strength: Portfolio remains defensively positioned with limited downside captured in today's results."
+        )
 
     if top_loser and _to_float(top_loser.get("dayPL")) < 0:
         sym = top_loser.get("symbol", "a holding")
         loss = _to_float(top_loser.get("dayPL"))
         total_loss = _to_float(top_loser.get("totalPL"))
-        insights.append(
-            f"⚠️ Watchlist: {sym} is dragging performance with a ${loss:,.2f} move on the session and ${total_loss:,.2f} unrealized drawdown."
+        watchlist_text = (
+            f"{sym} is dragging performance with a {_format_currency(loss)} move on the session and {_format_currency(total_loss)} unrealized drawdown."
         )
+        fallback_insights.append("⚠️ Watchlist: " + watchlist_text)
     elif worst_draw and _to_float(worst_draw.get("totalPL")) < 0:
         sym = worst_draw.get("symbol", "a holding")
         total_loss = _to_float(worst_draw.get("totalPL"))
-        insights.append(
-            f"⚠️ Watchlist: {sym} holds the deepest unrealized loss at ${total_loss:,.2f}; review its thesis."
+        fallback_insights.append(
+            "⚠️ Watchlist: " + f"{sym} holds the deepest unrealized loss at {_format_currency(total_loss)}; review its thesis."
         )
     elif not open_positions:
-        insights.append("⚠️ Watchlist: No active positions — verify that the policy is allowed to deploy capital as intended.")
+        fallback_insights.append(
+            "⚠️ Watchlist: No active positions — verify that the policy is allowed to deploy capital as intended."
+        )
+    else:
+        fallback_insights.append("⚠️ Watchlist: Positions remain orderly with no outsized drawdowns detected today.")
 
     recommendations: List[str] = []
     if cash_ratio > 0.45:
@@ -139,14 +178,68 @@ def generate_insights(req: InsightsRequest) -> dict:
             "consider lowering `guards.daily_loss_limit_pct` or adding stricter stop logic for underperforming names"
         )
     if avg_turnover > 0 and avg_turnover > 0.05 * equity:
-        recommendations.append("dial back trade frequency via a higher `rebalance_eps` or lower `max_step_change` to reduce churn")
+        recommendations.append(
+            "dial back trade frequency via a higher `rebalance_eps` or lower `max_step_change` to reduce churn"
+        )
     if not recommendations:
         recommendations.append(
             "continue monitoring regime detection and refresh the config snapshot after the next backtest to keep signals aligned"
         )
 
-    insights.append("🔧 Next tweaks: " + "; ".join(recommendations) + ".")
+    fallback_insights.append(
+        "🔧 Next tweaks: " + "; ".join(recommendations) + ". " + concentration_text
+    )
 
     account_value = equity if equity else invested_value + cash
 
-    return {"insights": insights, "accountValue": account_value, "bot": bot_name}
+    if _OLLAMA_AGENT:
+        prompt_payload: Dict[str, Any] = {
+            "account_summary": summary,
+            "positions": open_positions,
+            "transactions": transactions,
+            "calculated": {
+                "equity": equity,
+                "cash": cash,
+                "buying_power": buying_power,
+                "day_pl": day_pl,
+                "invested_value": invested_value,
+                "cash_ratio": cash_ratio,
+                "turnover_ratio": turnover_ratio,
+                "concentration": concentration,
+                "top_winner": top_winner,
+                "top_loser": top_loser,
+                "worst_draw": worst_draw,
+            },
+        }
+        if isinstance(portfolio, dict):
+            prompt_payload["portfolio_raw"] = {
+                key: value
+                for key, value in portfolio.items()
+                if key not in {"summary", "positions", "transactions"}
+            }
+
+        prompt = (
+            "You are Jarvis, a trading assistant that speaks in concise trading-desk briefs. "
+            "Review the provided brokerage snapshot JSON and craft a focused report. "
+            "Return strict JSON with keys 'insights' (an ordered list of four strings) and 'accountValue' (number). "
+            "Each insight should begin respectively with 'Overview:', '✅ Strength:', '⚠️ Watchlist:', and '🔧 Next tweaks:' "
+            "and reference configuration levers such as sizing or guards where relevant. Do not include any extra keys or prose.\n\n"
+            f"<DATA>\n{json.dumps(prompt_payload, indent=2, default=str)}\n</DATA>"
+        )
+
+        try:
+            raw_response = _OLLAMA_AGENT.generate(prompt, output_format="json")
+            parsed = json.loads(raw_response)
+            llm_insights = parsed.get("insights")
+            llm_account_value = parsed.get("accountValue", account_value)
+
+            if isinstance(llm_insights, list) and all(isinstance(item, str) for item in llm_insights):
+                try:
+                    account_value = float(llm_account_value)
+                except (TypeError, ValueError):
+                    pass
+                return {"insights": llm_insights, "accountValue": account_value, "bot": bot_name}
+        except Exception as exc:  # pragma: no cover - rely on fallback if agent fails
+            logger.warning("Falling back to rule-based insights: %s", exc)
+
+    return {"insights": fallback_insights, "accountValue": account_value, "bot": bot_name}


### PR DESCRIPTION
## Summary
- wire the insights controller to the shared Jarvis Ollama agent and prompt it for a structured report when available
- retain the rule-based overview/strength/watchlist/tweak narrative as a graceful fallback when the LLM call fails
- include portfolio metrics and computed ratios in the prompt payload to guide configuration tweak suggestions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a9c49ff08331a97ba4a420f6ed3e