### PR TITLE
Fix daily loss guard to respect session day open

### DIFF
--- a/stockbot/env/portfolio_env.py
+++ b/stockbot/env/portfolio_env.py
@@ -168,6 +168,7 @@ class PortfolioTradingEnv(gym.Env):
         self.risk_events: List[Dict] = []
         self.guardrails = LiveGuardrails() if LiveGuardrails else None
         self._canary_prev_stage = 0
+        self._risk_session: pd.Timestamp | None = None
 
     # ---------- helpers ----------
     def _ohlc(self, sym: str, i: int):
@@ -306,6 +307,7 @@ class PortfolioTradingEnv(gym.Env):
         if LiveGuardrails:
             self.guardrails = LiveGuardrails()
             self._canary_prev_stage = 0
+        self._risk_session = None
 
         return self._obs(self._i), {"i": self._i, "config": asdict(self.cfg)}
 
@@ -313,6 +315,16 @@ class PortfolioTradingEnv(gym.Env):
         a = np.asarray(action, dtype=np.float32)
         prices_prev_close = self._prices(self._i - 1)  # CLOSE[t-1]
         eq_prev_close = self.port.value(prices_prev_close)
+        self.risk_state.nav_current = eq_prev_close
+        session_key = None
+        try:
+            session_key = pd.Timestamp(self.src.index[self._i]).normalize()
+        except Exception:
+            session_key = None
+        if session_key is not None:
+            if self._risk_session is None or session_key != self._risk_session:
+                self._risk_session = session_key
+                self.risk_state.nav_day_open = self.risk_state.nav_current
         prev_w = np.array(
             [
                 (self.port.positions[sym].qty if sym in self.port.positions else 0.0)
@@ -359,7 +371,6 @@ class PortfolioTradingEnv(gym.Env):
             pass
         self.sizing_trace.append({"ts": self.src.index[self._i], **trace})
         self.risk_events.extend(events)
-        self.risk_state.nav_day_open = self.risk_state.nav_current
 
         # ---- plan fills using next bar open and ADV
         prices_next = np.array([self._ohlc(sym, self._i)[0] for sym in self.syms], dtype=np.float64)
@@ -476,7 +487,6 @@ class PortfolioTradingEnv(gym.Env):
         self._eq_net.append(eq_close_t)
         self._eq_gross.append(eq_close_t + total_cost)
         self.risk_state.nav_current = eq_close_t
-        self.risk_state.nav_day_open = eq_close_t
         for k in range(self.N):
             if abs(target_w[k] - prev_w[k]) > w_eps:
                 self._hold_since[k] = 0

--- a/stockbot/tests/test_portfolio_env_risk.py
+++ b/stockbot/tests/test_portfolio_env_risk.py
@@ -1,0 +1,88 @@
+from pathlib import Path
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from stockbot.env.config import (  # noqa: E402
+    EnvConfig,
+    EpisodeConfig,
+    ExecConfig,
+    FeatureConfig,
+    FeeModel,
+    MarginConfig,
+)
+from stockbot.env.portfolio_env import PortfolioTradingEnv  # noqa: E402
+
+
+class DummyPanel:
+    def __init__(self, df):
+        self.symbols = ["XYZ"]
+        self.panel = {"XYZ": df}
+        self.index = df.index
+        self._cols = list(df.columns)
+
+    def cols_required(self):
+        return self._cols
+
+
+def make_env():
+    idx = pd.to_datetime(
+        [
+            "2020-01-01 09:30:00",
+            "2020-01-01 10:30:00",
+            "2020-01-01 11:30:00",
+        ]
+    )
+    data = {
+        "open": [100.0, 100.0, 80.0],
+        "high": [100.0, 100.0, 80.0],
+        "low": [100.0, 80.0, 80.0],
+        "close": [100.0, 80.0, 80.0],
+        "volume": [1_000_000.0, 1_000_000.0, 1_000_000.0],
+    }
+    df = pd.DataFrame(data, index=idx)
+    panel = DummyPanel(df)
+    cfg = EnvConfig(
+        symbols=("XYZ",),
+        fees=FeeModel(
+            commission_per_share=0.0,
+            commission_pct_notional=0.0,
+            slippage_bps=0.0,
+        ),
+        exec=ExecConfig(participation_cap=1.0),
+        margin=MarginConfig(
+            cash_borrow_apr=0.0,
+            max_position_weight=1.0,
+            max_gross_leverage=1.0,
+            daily_loss_limit=0.10,
+        ),
+        episode=EpisodeConfig(
+            start_cash=1000.0,
+            lookback=1,
+            max_steps=3,
+            mapping_mode="tanh_leverage",
+        ),
+        features=FeatureConfig(use_custom_pipeline=False, indicators=()),
+    )
+    env = PortfolioTradingEnv(panel, cfg)
+    env.reset()
+    return env
+
+
+def test_daily_loss_limit_halts_and_flattens():
+    env = make_env()
+    action_long = np.array([5.0], dtype=np.float32)
+
+    # First step: take the long position and realize a 20% drawdown intraday.
+    env.step(action_long)
+    assert env.risk_state.nav_day_open == pytest.approx(env.cfg.episode.start_cash)
+
+    # Second step occurs within the same session; guard should halt trading.
+    _, _, _, _, info = env.step(action_long)
+
+    assert "daily_dd_halt" in info["risk_events"]
+    assert np.allclose(info["weights_capped"], 0.0)


### PR DESCRIPTION
## Summary
- refresh the environment risk state with the latest portfolio mark before applying guardrails
- only reset nav_day_open when a new trading session starts
- add a regression test that confirms the daily loss halt zeroes target weights

## Testing
- pytest stockbot/tests/test_portfolio_env_risk.py

------
https://chatgpt.com/codex/tasks/task_e_68d5f7d011248331b7ec7a1825bf9bd1