### PR TITLE
Enhance new training summaries and tooltips

### DIFF
--- a/frontend/src/components/Stockbot/NewTraining/DatasetSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/DatasetSection.tsx
@@ -1,10 +1,14 @@
 "use client";
 
+import { useMemo } from "react";
 import { AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { TooltipLabel } from "../shared/TooltipLabel";
+import { getTooltip } from "./strings";
+import { SectionSummary } from "./SectionSummary";
+import { summarizeDataset } from "./summaries";
 
 interface DatasetProps {
   symbols: string;
@@ -43,6 +47,21 @@ export function DatasetSection({
   trainEvalSplit,
   setTrainEvalSplit,
 }: DatasetProps) {
+  const summary = useMemo(
+    () =>
+      summarizeDataset({
+        symbols,
+        start,
+        end,
+        interval,
+        lookback,
+        evalWindow,
+        trainSplit: trainEvalSplit,
+        adjusted,
+      }),
+    [symbols, start, end, interval, lookback, evalWindow, trainEvalSplit, adjusted],
+  );
+
   return (
     <AccordionItem value="dataset">
       <AccordionTrigger>Dataset & Window</AccordionTrigger>
@@ -50,48 +69,48 @@ export function DatasetSection({
         <div className="grid md:grid-cols-2 gap-4 pt-2">
           <InputGroup
             label="Symbols"
-            tooltip="Comma-separated stock tickers"
+            tooltip={getTooltip("dataset", "symbols")}
             value={symbols}
             onChange={setSymbols}
             placeholder="AAPL,MSFT,…"
           />
           <InputGroup
             label="Interval"
-            tooltip="Data frequency such as 1d or 1h"
+            tooltip={getTooltip("dataset", "interval")}
             value={interval}
             onChange={setInterval}
             placeholder="1d"
           />
           <InputGroup
             label="Start"
-            tooltip="Start date for training data"
+            tooltip={getTooltip("dataset", "start")}
             value={start}
             onChange={setStart}
             type="date"
           />
           <InputGroup
             label="End"
-            tooltip="End date for training data"
+            tooltip={getTooltip("dataset", "end")}
             value={end}
             onChange={setEnd}
             type="date"
           />
           <InputGroup
             label="Lookback"
-            tooltip="Number of past bars provided in each observation"
+            tooltip={getTooltip("dataset", "lookback")}
             value={String(lookback)}
             onChange={(v) => setLookback(parseInt(v) || lookback)}
             type="number"
           />
           <InputGroup
             label="Eval Window"
-            tooltip="Calendar days for evaluation window (0=auto)"
+            tooltip={getTooltip("dataset", "evalWindow")}
             value={String(evalWindow)}
             onChange={(v) => setEvalWindow(parseInt(v) || 0)}
             type="number"
           />
           <div className="flex flex-col gap-1">
-            <TooltipLabel tooltip="How to split train vs evaluation data">Train/Eval Split</TooltipLabel>
+            <TooltipLabel tooltip={getTooltip("dataset", "trainEvalSplit")}>Train/Eval Split</TooltipLabel>
             <Select value={trainEvalSplit} onValueChange={setTrainEvalSplit}>
               <SelectTrigger>
                 <SelectValue />
@@ -106,12 +125,13 @@ export function DatasetSection({
           <div className="md:col-span-1">
             <SwitchGroup
               label="Adjusted Prices"
-              tooltip="Use prices adjusted for splits and dividends"
+              tooltip={getTooltip("dataset", "adjusted")}
               checked={adjusted}
               onChange={setAdjusted}
             />
           </div>
         </div>
+        <SectionSummary title="Dataset impact" headline={summary.headline} bullets={summary.bullets} />
       </AccordionContent>
     </AccordionItem>
   );

--- a/frontend/src/components/Stockbot/NewTraining/RewardLoggingSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/RewardLoggingSection.tsx
@@ -1,9 +1,13 @@
+import { useMemo } from "react";
 import { AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { safeNum } from "./utils";
 import { TooltipLabel } from "../shared/TooltipLabel";
+import { getTooltip } from "./strings";
+import { SectionSummary } from "./SectionSummary";
+import { summarizeReward } from "./summaries";
 
 
 /** <-- Use these in the parent useState initializers */
@@ -57,12 +61,20 @@ export function RewardLoggingSection({
   saveRegime,
   setSaveRegime,
 }: Props) {
-  const activePenalties =
-    (wDrawdown > 0 ? ["drawdown"] : [])
-      .concat(wTurnover > 0 ? ["turnover"] : [])
-      .concat(wVol > 0 ? ["vol"] : [])
-      .concat(wLeverage > 0 ? ["leverage"] : [])
-      .join(", ") || "none";
+  const summary = useMemo(
+    () =>
+      summarizeReward({
+        rewardBase,
+        wDrawdown,
+        wTurnover,
+        wVol,
+        wLeverage,
+        saveTb,
+        saveActions,
+        saveRegime,
+      }),
+    [rewardBase, wDrawdown, wTurnover, wVol, wLeverage, saveTb, saveActions, saveRegime],
+  );
 
   return (
     <AccordionItem value="reward">
@@ -70,7 +82,7 @@ export function RewardLoggingSection({
       <AccordionContent>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3 pt-2">
           <div className="flex items-center gap-2">
-            <TooltipLabel className="min-w-[120px]" tooltip="Base reward">
+            <TooltipLabel className="min-w-[120px]" tooltip={getTooltip("reward", "base")}>
               base
             </TooltipLabel>
             <Select value={rewardBase} onValueChange={(v) => setRewardBase(v as any)}>
@@ -84,7 +96,7 @@ export function RewardLoggingSection({
             </Select>
           </div>
 
-          <Field label="w_drawdown" tooltip="Drawdown penalty (discourage large peak-to-trough losses)">
+          <Field label="w_drawdown" tooltip={getTooltip("reward", "wDrawdown")}>
             <Input
               type="number"
               step="0.0001"
@@ -97,7 +109,7 @@ export function RewardLoggingSection({
             />
           </Field>
 
-          <Field label="w_turnover" tooltip="Turnover penalty (discourage frequent large rebalances)">
+          <Field label="w_turnover" tooltip={getTooltip("reward", "wTurnover")}>
             <Input
               type="number"
               step="0.0001"
@@ -110,7 +122,7 @@ export function RewardLoggingSection({
             />
           </Field>
 
-          <Field label="w_vol" tooltip="Realized volatility penalty (over a chosen window)">
+          <Field label="w_vol" tooltip={getTooltip("reward", "wVol")}>
             <Input
               type="number"
               step="0.0001"
@@ -123,7 +135,7 @@ export function RewardLoggingSection({
             />
           </Field>
 
-          <Field label="w_leverage" tooltip="Gross leverage penalty (discourage excessive exposure)">
+          <Field label="w_leverage" tooltip={getTooltip("reward", "wLeverage")}>
             <Input
               type="number"
               step="0.0001"
@@ -138,23 +150,20 @@ export function RewardLoggingSection({
 
           <div className="flex items-center gap-2">
             <Switch checked={saveTb} onCheckedChange={setSaveTb} />
-            <TooltipLabel tooltip="Save TensorBoard logs">save_tb</TooltipLabel>
+            <TooltipLabel tooltip={getTooltip("reward", "saveTb")}>save_tb</TooltipLabel>
           </div>
 
           <div className="flex items-center gap-2">
             <Switch checked={saveActions} onCheckedChange={setSaveActions} />
-            <TooltipLabel tooltip="Save action history">save_action_hist</TooltipLabel>
+            <TooltipLabel tooltip={getTooltip("reward", "saveActions")}>save_action_hist</TooltipLabel>
           </div>
 
           <div className="flex items-center gap-2">
             <Switch checked={saveRegime} onCheckedChange={setSaveRegime} />
-            <TooltipLabel tooltip="Save regime plots">save_regime_plots</TooltipLabel>
+            <TooltipLabel tooltip={getTooltip("reward", "saveRegime")}>save_regime_plots</TooltipLabel>
           </div>
         </div>
-
-        <div className="mt-3 text-xs text-muted-foreground border rounded px-3 py-2">
-          <b>Base:</b> {rewardBase} &nbsp;•&nbsp; <b>Active penalties:</b> {activePenalties}
-        </div>
+        <SectionSummary title="Reward summary" headline={summary.headline} bullets={summary.bullets} />
       </AccordionContent>
     </AccordionItem>
   );

--- a/frontend/src/components/Stockbot/NewTraining/SectionSummary.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/SectionSummary.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface SectionSummaryProps {
+  title: string;
+  headline?: string;
+  bullets?: string[];
+}
+
+export function SectionSummary({ title, headline, bullets = [] }: SectionSummaryProps) {
+  if (!headline && bullets.length === 0) return null;
+
+  return (
+    <div className="mt-4 rounded-md border bg-muted/40 p-3 space-y-2">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">{title}</div>
+      {headline && <div className="text-sm font-medium text-foreground">{headline}</div>}
+      {bullets.length > 0 && (
+        <ul className="list-disc space-y-1 pl-4 text-xs text-muted-foreground">
+          {bullets.map((line, idx) => (
+            <li key={idx}>{line}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Stockbot/NewTraining/SizingSection.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/SizingSection.tsx
@@ -7,6 +7,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Switch } from "@/components/ui/switch";
 import { safeNum } from "./utils";
 import { TooltipLabel } from "../shared/TooltipLabel";
+import { getTooltip } from "./strings";
+import { SectionSummary } from "./SectionSummary";
+import { summarizeSizing } from "./summaries";
 
 /** <-- Use these in your parent useState initializers */
 export const DEFAULT_SIZING = {
@@ -106,8 +109,48 @@ export function SizingSection({
   setMinHoldBars,
 }: Props) {
   const oneBarTarget = useMemo(() => oneBar(volTarget, interval), [volTarget, interval]);
-  const cashFloor = useMemo(() => (mappingMode === "simplex_cash" ? Math.max(0, 1 - (investMax || 0)) : 0), [mappingMode, investMax]);
   const clampPinned = useMemo(() => volEnabled && clampMin === 0 && clampMax === 0, [volEnabled, clampMin, clampMax]);
+  const summary = useMemo(
+    () =>
+      summarizeSizing({
+        mappingMode,
+        investMax,
+        grossLevCap,
+        maxStepChange,
+        rebalanceEps,
+        minHoldBars,
+        kellyEnabled,
+        kellyLambda,
+        kellyFMax,
+        kellyEmaAlpha,
+        volEnabled,
+        volTarget,
+        volMin,
+        clampMin,
+        clampMax,
+        dailyLoss,
+        perNameCap,
+      }),
+    [
+      mappingMode,
+      investMax,
+      grossLevCap,
+      maxStepChange,
+      rebalanceEps,
+      minHoldBars,
+      kellyEnabled,
+      kellyLambda,
+      kellyFMax,
+      kellyEmaAlpha,
+      volEnabled,
+      volTarget,
+      volMin,
+      clampMin,
+      clampMax,
+      dailyLoss,
+      perNameCap,
+    ],
+  );
 
   return (
     <AccordionItem value="sizing">
@@ -115,7 +158,7 @@ export function SizingSection({
       <AccordionContent>
         <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-3 pt-2">
           <div className="flex items-center gap-2">
-            <TooltipLabel className="min-w-[130px]" tooltip="Mapping from logits to weights">
+            <TooltipLabel className="min-w-[130px]" tooltip={getTooltip("sizing", "mappingMode")}>
               mapping_mode
             </TooltipLabel>
             <Select value={mappingMode} onValueChange={(v) => setMappingMode(v as any)}>
@@ -130,7 +173,7 @@ export function SizingSection({
           </div>
 
           {mappingMode === "simplex_cash" && (
-            <Field label="invest_max" tooltip="Max investable cash fraction (0–1)">
+            <Field label="invest_max" tooltip={getTooltip("sizing", "investMax")}>
               <Input
                 type="number"
                 step="0.01"
@@ -145,7 +188,7 @@ export function SizingSection({
           )}
 
           {mappingMode === "tanh_leverage" && (
-            <Field label="gross_leverage_cap" tooltip="Absolute gross leverage cap (e.g., 1.5)">
+            <Field label="gross_leverage_cap" tooltip={getTooltip("sizing", "grossLevCap")}>
               <Input
                 type="number"
                 step="0.1"
@@ -159,7 +202,7 @@ export function SizingSection({
             </Field>
           )}
 
-          <Field label="max_step_change" tooltip="Max portfolio turnover per step (0–1)">
+          <Field label="max_step_change" tooltip={getTooltip("sizing", "maxStepChange")}>
             <Input
               type="number"
               step="0.005"
@@ -172,7 +215,7 @@ export function SizingSection({
             />
           </Field>
 
-          <Field label="rebalance_eps" tooltip="Rebalance threshold on absolute weight change">
+          <Field label="rebalance_eps" tooltip={getTooltip("sizing", "rebalanceEps")}>
             <Input
               type="number"
               step="0.001"
@@ -185,7 +228,7 @@ export function SizingSection({
             />
           </Field>
 
-          <Field label="min_hold_bars" tooltip="Minimum bars to hold before flipping position">
+          <Field label="min_hold_bars" tooltip={getTooltip("sizing", "minHoldBars")}>
             <Input
               type="number"
               step="1"
@@ -200,7 +243,7 @@ export function SizingSection({
 
           {/* Kelly */}
           <div className="flex items-center gap-2">
-            <TooltipLabel className="min-w-[130px]" tooltip="Enable Kelly sizing">
+            <TooltipLabel className="min-w-[130px]" tooltip={getTooltip("sizing", "kellyEnabled")}>
               kelly.enabled
             </TooltipLabel>
             <Switch checked={kellyEnabled} onCheckedChange={setKellyEnabled} />
@@ -208,7 +251,7 @@ export function SizingSection({
 
           {kellyEnabled && (
             <>
-              <Field label="kelly.lambda" tooltip="Kelly fraction scaler λ (0–2)">
+              <Field label="kelly.lambda" tooltip={getTooltip("sizing", "kellyLambda")}>
                 <Input
                   type="number"
                   step="0.1"
@@ -221,7 +264,7 @@ export function SizingSection({
                 />
               </Field>
 
-              <Field label="kelly.f_max" tooltip="Kelly exposure cap (|f| ≤ f_max)">
+              <Field label="kelly.f_max" tooltip={getTooltip("sizing", "kellyFMax")}>
                 <Input
                   type="number"
                   step="0.1"
@@ -234,7 +277,7 @@ export function SizingSection({
                 />
               </Field>
 
-              <Field label="kelly.ema_alpha" tooltip="EMA smoothing for f_t (0.01–0.99)">
+              <Field label="kelly.ema_alpha" tooltip={getTooltip("sizing", "kellyEmaAlpha")}>
                 <Input
                   type="number"
                   step="0.05"
@@ -251,7 +294,7 @@ export function SizingSection({
 
           {/* Vol target */}
           <div className="flex items-center gap-2">
-            <TooltipLabel className="min-w-[130px]" tooltip="Enable volatility targeting">
+            <TooltipLabel className="min-w-[130px]" tooltip={getTooltip("sizing", "volEnabled")}>
               vol_target.enabled
             </TooltipLabel>
             <Switch checked={volEnabled} onCheckedChange={setVolEnabled} />
@@ -259,7 +302,7 @@ export function SizingSection({
 
           {volEnabled && (
             <>
-              <Field label="vol_target.annual_target" tooltip="Annualized vol target (e.g., 0.10)">
+              <Field label="vol_target.annual_target" tooltip={getTooltip("sizing", "volTarget")}>
                 <Input
                   type="number"
                   step="0.01"
@@ -276,7 +319,7 @@ export function SizingSection({
                 1-bar target: {oneBarTarget.toFixed(4)}
               </div>
 
-              <Field label="vol_target.min_vol" tooltip="Minimum realized vol floor for scaling">
+              <Field label="vol_target.min_vol" tooltip={getTooltip("sizing", "volMin")}>
                 <Input
                   type="number"
                   step="0.01"
@@ -289,7 +332,7 @@ export function SizingSection({
                 />
               </Field>
 
-              <Field label="vol_target.clamp.min" tooltip="Lower clamp on scaling factor">
+              <Field label="vol_target.clamp.min" tooltip={getTooltip("sizing", "clampMin")}>
                 <Input
                   type="number"
                   step="0.05"
@@ -302,7 +345,7 @@ export function SizingSection({
                 />
               </Field>
 
-              <Field label="vol_target.clamp.max" tooltip="Upper clamp on scaling factor">
+              <Field label="vol_target.clamp.max" tooltip={getTooltip("sizing", "clampMax")}>
                 <Input
                   type="number"
                   step="0.1"
@@ -324,7 +367,7 @@ export function SizingSection({
           )}
 
           {/* Guards */}
-          <Field label="guards.daily_loss_limit_pct" tooltip="Flatten & halt for the day if loss exceeds this %">
+          <Field label="guards.daily_loss_limit_pct" tooltip={getTooltip("sizing", "dailyLoss")}>
             <Input
               type="number"
               step="0.1"
@@ -337,7 +380,7 @@ export function SizingSection({
             />
           </Field>
 
-          <Field label="guards.per_name_weight_cap" tooltip="Max absolute weight per asset">
+          <Field label="guards.per_name_weight_cap" tooltip={getTooltip("sizing", "perNameCap")}>
             <Input
               type="number"
               step="0.01"
@@ -350,13 +393,8 @@ export function SizingSection({
             />
           </Field>
 
-          {/* Derived hint */}
-          {mappingMode === "simplex_cash" && (
-            <div className="md:col-span-2 lg:col-span-3 text-xs text-muted-foreground border rounded px-3 py-2">
-              <b>Effective cash floor:</b> {(cashFloor * 100).toFixed(0)}% (from invest_max = {investMax})
-            </div>
-          )}
         </div>
+        <SectionSummary title="Sizing summary" headline={summary.headline} bullets={summary.bullets} />
       </AccordionContent>
     </AccordionItem>
   );

--- a/frontend/src/components/Stockbot/NewTraining/index.tsx
+++ b/frontend/src/components/Stockbot/NewTraining/index.tsx
@@ -23,6 +23,7 @@ import { Label } from "@/components/ui/label";
 import ValidationSummaryCard from "./ValidationSummaryCard";
 import { computeValidation } from "./validation";
 import { TERMINAL_STATUSES, useTrainingRun } from "./useTrainingRun";
+import { buildStrategyNarrative, summarizeDataset, summarizeReward, summarizeSizing } from "./summaries";
 
 export default function NewTraining({
   onJobCreated,
@@ -298,6 +299,92 @@ export default function NewTraining({
 
   const validation = useMemo(() => computeValidation(gatherState()), [gatherState]);
 
+  const datasetSummary = useMemo(
+    () =>
+      summarizeDataset({
+        symbols,
+        start,
+        end,
+        interval,
+        lookback,
+        evalWindow,
+        trainSplit,
+        adjusted,
+      }),
+    [symbols, start, end, interval, lookback, evalWindow, trainSplit, adjusted],
+  );
+
+  const sizingSummary = useMemo(
+    () =>
+      summarizeSizing({
+        mappingMode,
+        investMax,
+        grossLevCap,
+        maxStepChange,
+        rebalanceEps,
+        minHoldBars,
+        kellyEnabled,
+        kellyLambda,
+        kellyFMax,
+        kellyEmaAlpha,
+        volEnabled,
+        volTarget,
+        volMin,
+        clampMin,
+        clampMax,
+        dailyLoss,
+        perNameCap,
+      }),
+    [
+      mappingMode,
+      investMax,
+      grossLevCap,
+      maxStepChange,
+      rebalanceEps,
+      minHoldBars,
+      kellyEnabled,
+      kellyLambda,
+      kellyFMax,
+      kellyEmaAlpha,
+      volEnabled,
+      volTarget,
+      volMin,
+      clampMin,
+      clampMax,
+      dailyLoss,
+      perNameCap,
+    ],
+  );
+
+  const rewardSummary = useMemo(
+    () =>
+      summarizeReward({
+        rewardBase,
+        wDrawdown,
+        wTurnover,
+        wVol,
+        wLeverage,
+        saveTb,
+        saveActions,
+        saveRegime,
+      }),
+    [rewardBase, wDrawdown, wTurnover, wVol, wLeverage, saveTb, saveActions, saveRegime],
+  );
+
+  const strategyNarrative = useMemo(
+    () => buildStrategyNarrative({ dataset: datasetSummary, sizing: sizingSummary, reward: rewardSummary }),
+    [datasetSummary, sizingSummary, rewardSummary],
+  );
+
+  const strategyBulletGroups = useMemo(
+    () => [
+      { label: "Dataset", bullets: datasetSummary.bullets.slice(0, 2) },
+      { label: "Sizing", bullets: sizingSummary.bullets.slice(0, 2) },
+      { label: "Reward", bullets: rewardSummary.bullets.slice(0, 2) },
+    ],
+    [datasetSummary, sizingSummary, rewardSummary],
+  );
+
   const applyPayloadToState = (payload: TrainPayload) => {
     const toNumber = (value: unknown): number | undefined => {
       if (typeof value === "number") return value;
@@ -555,6 +642,23 @@ export default function NewTraining({
           >
             {submitting && !status ? "Submitting…" : isRunning ? "Running…" : "Start Training"}
           </Button>
+        </div>
+      </div>
+
+      <div className="rounded-md border bg-muted/40 p-4 space-y-3">
+        <div className="text-sm font-semibold text-foreground">Strategy Summary</div>
+        <p className="text-sm text-muted-foreground">{strategyNarrative}</p>
+        <div className="grid gap-3 md:grid-cols-3 text-xs text-muted-foreground">
+          {strategyBulletGroups.map(({ label, bullets }) => (
+            <div key={label} className="space-y-1">
+              <div className="text-[10px] font-semibold uppercase tracking-wide text-foreground/70">{label}</div>
+              <ul className="list-disc space-y-1 pl-4">
+                {bullets.map((line, idx) => (
+                  <li key={`${label}-${idx}`}>{line}</li>
+                ))}
+              </ul>
+            </div>
+          ))}
         </div>
       </div>
 

--- a/frontend/src/components/Stockbot/NewTraining/strings.ts
+++ b/frontend/src/components/Stockbot/NewTraining/strings.ts
@@ -1,0 +1,81 @@
+export const tooltips = {
+  dataset: {
+    symbols:
+      "Tickers the agent can trade; this sets the action space and required market history.",
+    interval:
+      "Sampling cadence for observations; faster bars create more decisions and short-term behaviour.",
+    start:
+      "First date of historical data; starting earlier broadens regimes but increases download volume.",
+    end:
+      "Final date of the dataset; controls how recent evaluation data is.",
+    lookback:
+      "Bars included in each observation; longer lookbacks favour slower context but enlarge the state.",
+    evalWindow:
+      "Calendar days reserved for evaluation before training resumes; 0 lets the split rule decide.",
+    trainEvalSplit:
+      "How to allocate history between training and evaluation, affecting score comparability.",
+    adjusted:
+      "Use corporate-action adjusted prices; turning this off trades raw quotes with split/dividend jumps.",
+  },
+  sizing: {
+    mappingMode:
+      "Transforms policy logits into tradable weights, choosing between cash-aware or leverage-aware bands.",
+    investMax:
+      "Maximum invested capital in simplex mode; the remainder is enforced cash buffer.",
+    grossLevCap:
+      "Absolute gross leverage limit when using tanh mapping; caps combined long plus short exposure.",
+    maxStepChange:
+      "Largest portfolio turnover per decision; tighter caps smooth transitions but slow reactions.",
+    rebalanceEps:
+      "Ignores target shifts smaller than this threshold to cut down on churn and fees.",
+    minHoldBars:
+      "Bars an allocation must be held before flipping, to avoid rapid oscillations.",
+    kellyEnabled:
+      "Layer Kelly sizing on top of policy weights to scale exposure with estimated edge.",
+    kellyLambda:
+      "Scales the Kelly fraction; smaller values dampen leverage swings.",
+    kellyFMax:
+      "Caps the Kelly multiplier so runaway signals cannot over-leverage the book.",
+    kellyEmaAlpha:
+      "EMA smoothing for Kelly estimates; higher alpha reacts faster with more noise.",
+    volEnabled:
+      "Enable realised-volatility targeting to keep risk near a desired level.",
+    volTarget:
+      "Annualised volatility goal that resizes weights up or down to stabilise risk.",
+    volMin:
+      "Floor on the realised vol estimate so quiet markets do not blow up the scaling factor.",
+    clampMin:
+      "Lower bound on the vol scaling multiplier to avoid deleveraging to zero.",
+    clampMax:
+      "Upper bound on the vol scaling multiplier to contain leverage in calm regimes.",
+    dailyLoss:
+      "Percent loss in a day that triggers flatten-and-halt risk guard.",
+    perNameCap:
+      "Absolute per-asset weight cap that enforces diversification across symbols.",
+  },
+  reward: {
+    base:
+      "Base reward shaping; log_nav emphasises compounding while delta_nav follows raw PnL swings.",
+    wDrawdown:
+      "Penalty weighting for drawdowns to favour smoother equity curves.",
+    wTurnover:
+      "Penalty for turnover that discourages constant rebalancing and trading costs.",
+    wVol:
+      "Penalty for realised volatility to temper aggressive swings.",
+    wLeverage:
+      "Penalty on gross leverage to rein in oversized positions.",
+    saveTb:
+      "Persist TensorBoard metrics for deeper diagnostics after training.",
+    saveActions:
+      "Record action history so executions can be replayed or stress-tested.",
+    saveRegime:
+      "Store inferred regime plots for later inspection of market states.",
+  },
+} as const;
+
+export type TooltipSection = keyof typeof tooltips;
+export type TooltipKey<T extends TooltipSection> = keyof (typeof tooltips)[T];
+
+export function getTooltip<T extends TooltipSection>(section: T, key: TooltipKey<T>): string {
+  return tooltips[section][key];
+}

--- a/frontend/src/components/Stockbot/NewTraining/summaries.ts
+++ b/frontend/src/components/Stockbot/NewTraining/summaries.ts
@@ -1,0 +1,244 @@
+export type Interval = "1d" | "1h" | "15m";
+
+export interface DatasetSummaryInput {
+  symbols: string;
+  start: string;
+  end: string;
+  interval: Interval;
+  lookback: number;
+  evalWindow: number;
+  trainSplit: string;
+  adjusted: boolean;
+}
+
+export interface SizingSummaryInput {
+  mappingMode: "simplex_cash" | "tanh_leverage";
+  investMax: number;
+  grossLevCap: number;
+  maxStepChange: number;
+  rebalanceEps: number;
+  minHoldBars?: number;
+  kellyEnabled: boolean;
+  kellyLambda: number;
+  kellyFMax: number;
+  kellyEmaAlpha: number;
+  volEnabled: boolean;
+  volTarget: number;
+  volMin: number;
+  clampMin: number;
+  clampMax: number;
+  dailyLoss: number;
+  perNameCap: number;
+}
+
+export interface RewardSummaryInput {
+  rewardBase: "delta_nav" | "log_nav";
+  wDrawdown: number;
+  wTurnover: number;
+  wVol: number;
+  wLeverage: number;
+  saveTb: boolean;
+  saveActions: boolean;
+  saveRegime: boolean;
+}
+
+export interface SectionSummaryContent {
+  headline: string;
+  bullets: string[];
+}
+
+export function summarizeDataset(input: DatasetSummaryInput): SectionSummaryContent {
+  const symbolList = input.symbols
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const symbolCount = symbolList.length;
+  const barsPerDay = intervalBarsPerDay(input.interval);
+  const lookbackDays = input.lookback > 0 ? input.lookback / barsPerDay : 0;
+  const lookbackText = input.lookback
+    ? `${input.lookback} bars (~${formatDuration(lookbackDays)})`
+    : "No lookback bars configured";
+
+  const spanDays = spanBetween(input.start, input.end);
+
+  const headlineParts = [
+    symbolCount > 0
+      ? `${symbolCount} symbol${symbolCount === 1 ? "" : "s"}`
+      : "No symbols",
+    `on ${input.interval} bars`,
+    spanDays > 0 ? `from ${input.start} to ${input.end}` : "with unspecified window",
+  ];
+
+  const headline = `${headlineParts.join(" ")}.`;
+
+  const bullets: string[] = [
+    `Lookback coverage: ${lookbackText}.`,
+  ];
+
+  if (input.evalWindow > 0) {
+    bullets.push(
+      `Evaluation holds out the last ${input.evalWindow} calendar day${input.evalWindow === 1 ? "" : "s"} before retraining.`,
+    );
+  } else {
+    bullets.push("Evaluation window defaults to the selected split rule.");
+  }
+
+  bullets.push(`Train/eval split: ${describeSplit(input.trainSplit)}.`);
+  bullets.push(
+    input.adjusted
+      ? "Prices are adjusted for splits and dividends to keep returns smooth."
+      : "Raw prices are used, so splits/dividends will appear as jumps in returns.",
+  );
+
+  return { headline, bullets };
+}
+
+export function summarizeSizing(input: SizingSummaryInput): SectionSummaryContent {
+  const bullets: string[] = [];
+  let headline: string;
+
+  if (input.mappingMode === "simplex_cash") {
+    const cashFloor = clamp01(1 - (Number.isFinite(input.investMax) ? input.investMax : 0));
+    const investPct = formatPct(input.investMax);
+    headline = `Simplex mapping deploys up to ${investPct} of capital, leaving a ${formatPct(cashFloor)} cash floor.`;
+  } else {
+    headline = `Tanh leverage mapping allows roughly ±${input.grossLevCap.toFixed(1)}x gross exposure.`;
+  }
+
+  bullets.push(
+    `Turnover guard: max_step_change ${formatPct(input.maxStepChange)} with rebalance_eps ${formatPct(input.rebalanceEps)}.`,
+  );
+
+  if (Number.isFinite(input.minHoldBars) && (input.minHoldBars ?? 0) > 0) {
+    bullets.push(`Min holding period: ${(input.minHoldBars ?? 0).toFixed(0)} bar${(input.minHoldBars ?? 0) === 1 ? "" : "s"}.`);
+  }
+
+  if (input.kellyEnabled) {
+    bullets.push(
+      `Kelly overlay scales exposure (λ=${input.kellyLambda.toFixed(2)}, f_max=${input.kellyFMax.toFixed(1)}, ema_alpha=${input.kellyEmaAlpha.toFixed(2)}).`,
+    );
+  } else {
+    bullets.push("Kelly overlay disabled; policy weights flow through unscaled.");
+  }
+
+  if (input.volEnabled) {
+    bullets.push(
+      `Vol targeting aims for ${formatPct(input.volTarget)} annual risk with clamp ${input.clampMin.toFixed(2)}–${input.clampMax.toFixed(2)} and floor ${formatPct(input.volMin)}.`,
+    );
+  } else {
+    bullets.push("Vol targeting disabled; exposure is left to policy and guards.");
+  }
+
+  const guards: string[] = [];
+  if (input.dailyLoss > 0) {
+    guards.push(`daily loss ${formatPct(input.dailyLoss)}`);
+  }
+  if (input.perNameCap > 0) {
+    guards.push(`per-name cap ${formatPct(input.perNameCap)}`);
+  }
+  bullets.push(
+    guards.length > 0
+      ? `Risk guards active: ${guards.join(", ")}.`
+      : "No additional risk guards beyond mapping and overlays.",
+  );
+
+  return { headline, bullets };
+}
+
+export function summarizeReward(input: RewardSummaryInput): SectionSummaryContent {
+  const headline =
+    input.rewardBase === "log_nav"
+      ? "Reward focuses on log returns, reinforcing steady compounding."
+      : "Reward follows delta NAV, tracking raw profit swings.";
+
+  const penalties = [
+    input.wDrawdown > 0 ? `drawdown (${input.wDrawdown})` : null,
+    input.wTurnover > 0 ? `turnover (${input.wTurnover})` : null,
+    input.wVol > 0 ? `vol (${input.wVol})` : null,
+    input.wLeverage > 0 ? `leverage (${input.wLeverage})` : null,
+  ].filter(Boolean);
+
+  const bullets: string[] = [];
+  bullets.push(
+    penalties.length > 0
+      ? `Active penalties: ${penalties.join(", ")}.`
+      : "No auxiliary penalties; optimisation leans solely on the base reward.",
+  );
+
+  const logging: string[] = [];
+  if (input.saveTb) logging.push("TensorBoard");
+  if (input.saveActions) logging.push("action history");
+  if (input.saveRegime) logging.push("regime plots");
+
+  bullets.push(
+    logging.length > 0
+      ? `Artifacts saved: ${logging.join(", ")}.`
+      : "No diagnostic artifacts will be persisted.",
+  );
+
+  return { headline, bullets };
+}
+
+export function buildStrategyNarrative(sections: {
+  dataset: SectionSummaryContent;
+  sizing: SectionSummaryContent;
+  reward: SectionSummaryContent;
+}): string {
+  return [sections.dataset.headline, sections.sizing.headline, sections.reward.headline]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function intervalBarsPerDay(interval: Interval): number {
+  switch (interval) {
+    case "1d":
+      return 1;
+    case "1h":
+      return 6.5;
+    case "15m":
+      return 26;
+    default:
+      return 1;
+  }
+}
+
+function spanBetween(start: string, end: string): number {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) return 0;
+  const diffMs = endDate.getTime() - startDate.getTime();
+  return diffMs > 0 ? diffMs / (1000 * 60 * 60 * 24) : 0;
+}
+
+function formatDuration(days: number): string {
+  if (!Number.isFinite(days) || days <= 0) return "0 days";
+  if (days < 5) return `${days.toFixed(1)} trading day${days === 1 ? "" : "s"}`;
+  if (days < 45) return `${days.toFixed(0)} trading days`;
+  const months = days / 21;
+  if (months < 18) return `${months.toFixed(months >= 3 ? 0 : 1)} month${months < 1.5 ? "" : "s"}`;
+  const years = days / 252;
+  return `${years.toFixed(years >= 3 ? 0 : 1)} year${years < 1.5 ? "" : "s"}`;
+}
+
+function describeSplit(split: string): string {
+  switch (split) {
+    case "last_year":
+      return "Train on history before the most recent year and validate on the latest year";
+    case "80_20":
+      return "80% training / 20% evaluation chronological split";
+    case "custom_ranges":
+      return "Custom date ranges supplied in payload";
+    default:
+      return split;
+  }
+}
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function formatPct(value: number): string {
+  if (!Number.isFinite(value)) return "0%";
+  return `${(value * 100).toFixed(value * 100 >= 10 ? 0 : 1)}%`;
+}


### PR DESCRIPTION
## Summary
- centralize the New Training tooltip copy in a shared helper to keep messaging consistent
- add reusable section summaries that describe dataset, sizing, and reward implications inline
- surface an aggregated strategy summary panel above the form actions that narrates expected bot behaviour

## Testing
- npm run lint *(fails: `next` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d600ba49008331826df29cee513592