### PR TITLE
Recreate BWA Studio landing page and add aurora background

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -194,5 +194,31 @@
     top: -25vh;
     left: -20vw;
   }
-}
 
+  @keyframes auroraDrift {
+    0% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.45; }
+    50% { transform: translate3d(5vw, -6vh, 0) scale(1.08); opacity: 0.75; }
+    100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.55; }
+  }
+
+  .aurora {
+    position: absolute;
+    inset: -20%;
+    background: radial-gradient(circle at 30% 30%, rgba(124, 58, 237, 0.35), transparent 45%),
+      radial-gradient(circle at 70% 20%, rgba(217, 70, 239, 0.28), transparent 40%),
+      radial-gradient(circle at 60% 70%, rgba(59, 130, 246, 0.2), transparent 45%);
+    filter: blur(30px);
+    mix-blend-mode: screen;
+    animation: auroraDrift 18s ease-in-out infinite;
+  }
+
+  .aurora--two {
+    animation-duration: 22s;
+    animation-delay: -6s;
+  }
+
+  .aurora--three {
+    animation-duration: 26s;
+    animation-delay: -12s;
+  }
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,15 +1,15 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Space_Grotesk } from "next/font/google";
 import "./globals.css";
 import LayoutWrapper from "@/components/layout/LayoutWrapper";
 import DebugBridge from "@/components/DebugBridge";
 
-
 const inter = Inter({ subsets: ["latin"] });
+const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-display" });
 
 export const metadata: Metadata = {
-  title: "Jarvis StockBot",
-  description: "AI-Powered Trading Assistant",
+  title: "BWA Studio",
+  description: "Motion-forward product experiences for trading and AI teams.",
 };
 
 export default function RootLayout({
@@ -19,13 +19,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark" data-accent="violet">
-      <body className={inter.className}>
-        {/* These divs render the blobs. */}
+      <body className={`${inter.className} ${spaceGrotesk.variable}`}>
         <div className="blob blob-accent"></div>
         <div className="blob blob-blue"></div>
 
-        {/* This wrapper ensures your content appears ON TOP of the blobs. */}
-        {/* ADDED min-h-screen to prevent the background cutoff on short pages. */}
         <div className="relative z-10 flex min-h-screen flex-col">
           <DebugBridge />
           <LayoutWrapper>{children}</LayoutWrapper>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -6,286 +6,292 @@ import { gsap } from "gsap";
 import { ScrollTrigger } from "gsap/ScrollTrigger";
 import { Button } from "@/components/ui/button";
 import {
-  Card, CardContent, CardHeader, CardTitle, CardDescription,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
-  Bot, Rocket, Brain, BarChart2, Signal, Database, TrendingUp, Shield, KeyRound, Lock, Workflow, PlayCircle, Rocket as Rocket2, LineChart, Zap,
+  ArrowUpRight,
+  Bot,
+  Cpu,
+  Layers,
+  LineChart,
+  Sparkles,
+  Star,
+  Terminal,
+  Workflow,
 } from "lucide-react";
 
-/** Revamped marketing page — no specific broker names, no testimonials, updated stats. */
+const highlights = [
+  {
+    title: "AI-driven product experiences",
+    description: "Human-first UX paired with real-time signals, automation, and guardrails.",
+    icon: <Sparkles className="h-5 w-5 text-violet-300" />,
+  },
+  {
+    title: "Reactive, motion-forward interfaces",
+    description: "GSAP micro-interactions, smooth scroll stories, and kinetic layouts.",
+    icon: <Workflow className="h-5 w-5 text-indigo-300" />,
+  },
+  {
+    title: "Modular front-end systems",
+    description: "Tailwind + shadcn components built for velocity and consistency.",
+    icon: <Layers className="h-5 w-5 text-fuchsia-300" />,
+  },
+];
+
+const featuredWork = [
+  {
+    title: "Signal Desk",
+    description: "A real-time trading cockpit with chart overlays, alerts, and position routing.",
+    tags: ["Dashboard", "Realtime", "Design"],
+  },
+  {
+    title: "Atlas Backtester",
+    description: "Scenario-driven backtests with Monte Carlo variance maps and exportable reports.",
+    tags: ["Analytics", "Data Viz", "Research"],
+  },
+  {
+    title: "BWA Studio",
+    description: "A sleek marketing site with cinematic motion and clear conversion paths.",
+    tags: ["Brand", "Landing", "GSAP"],
+  },
+];
+
+const stack = [
+  { label: "React + Router", icon: <Bot className="h-4 w-4" /> },
+  { label: "GSAP + ScrollTrigger", icon: <Star className="h-4 w-4" /> },
+  { label: "Tailwind + shadcn/ui", icon: <Layers className="h-4 w-4" /> },
+  { label: "Realtime APIs", icon: <Terminal className="h-4 w-4" /> },
+  { label: "AI Pipelines", icon: <Cpu className="h-4 w-4" /> },
+  { label: "Market Analytics", icon: <LineChart className="h-4 w-4" /> },
+];
+
 export default function LandingPage() {
   const heroRef = useRef<HTMLDivElement>(null);
-  const statsRef = useRef<HTMLDivElement>(null);
-  const featuresRef = useRef<HTMLDivElement>(null);
-  const stepsRef = useRef<HTMLDivElement>(null);
-  const previewRef = useRef<HTMLDivElement>(null);
-  const trustRef = useRef<HTMLDivElement>(null);
-  const ctaRef = useRef<HTMLDivElement>(null);
+  const sectionRefs = useRef<HTMLElement[]>([]);
+
+  const registerSection = (el: HTMLElement | null) => {
+    if (el && !sectionRefs.current.includes(el)) {
+      sectionRefs.current.push(el);
+    }
+  };
 
   useEffect(() => {
     gsap.registerPlugin(ScrollTrigger);
     const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     if (reduce) return;
 
-    const fadeUp = (el: Element | null, offset = 40, delay = 0) => {
-      if (!el) return;
+    if (heroRef.current) {
       gsap.fromTo(
-        el,
-        { opacity: 0, y: offset },
+        heroRef.current,
+        { opacity: 0, y: 35 },
+        { opacity: 1, y: 0, duration: 0.8, ease: "power2.out" }
+      );
+    }
+
+    sectionRefs.current.forEach((section, index) => {
+      gsap.fromTo(
+        section,
+        { opacity: 0, y: 30 },
         {
-          opacity: 1, y: 0, duration: 0.7, ease: "power2.out", delay,
-          scrollTrigger: { trigger: el, start: "top 85%", once: true },
+          opacity: 1,
+          y: 0,
+          duration: 0.7,
+          ease: "power2.out",
+          delay: index * 0.05,
+          scrollTrigger: { trigger: section, start: "top 85%", once: true },
         }
       );
-    };
+    });
 
-    [heroRef, statsRef, featuresRef, stepsRef, previewRef, trustRef, ctaRef].forEach((r, i) =>
-      fadeUp(r?.current!, 30, i * 0.05)
-    );
-
-    return () => ScrollTrigger.getAll().forEach((st) => st.kill());
+    return () => ScrollTrigger.getAll().forEach((trigger) => trigger.kill());
   }, []);
 
   return (
     <div className="relative w-full overflow-hidden">
       <Aurora />
 
-      {/* NAV */}
       <header className="relative z-10 mx-auto flex max-w-6xl items-center justify-between px-6 py-6">
         <Link href="/" className="flex items-center gap-2">
-          <span className="inline-flex size-8 items-center justify-center rounded-md bg-white/5 ring-1 ring-white/10">
+          <span className="inline-flex size-9 items-center justify-center rounded-md bg-white/5 ring-1 ring-white/10">
             <Bot className="h-4 w-4 text-white/90" />
           </span>
           <span className="text-lg font-semibold tracking-tight bg-gradient-to-r from-indigo-300 via-violet-300 to-fuchsia-300 bg-clip-text text-transparent">
-            Jarvis StockBot
+            BWA Studio
           </span>
         </Link>
-        <div className="flex items-center gap-2">
-          <Badge variant="outline" className="border-white/15 text-white/70">Paper & Live</Badge>
-          <Badge variant="outline" className="border-white/15 text-white/70">Broker-neutral</Badge>
-          <Button asChild className="ml-3 btn-gradient">
-            <Link href="/auth">Get Started</Link>
-          </Button>
-        </div>
+        <nav className="hidden items-center gap-5 text-sm text-white/70 md:flex">
+          <a href="#work" className="hover:text-white">Work</a>
+          <a href="#process" className="hover:text-white">Process</a>
+          <a href="#stack" className="hover:text-white">Stack</a>
+          <a href="#contact" className="hover:text-white">Contact</a>
+        </nav>
+        <Button asChild className="btn-gradient">
+          <Link href="/auth">Launch Demo</Link>
+        </Button>
       </header>
 
-      {/* HERO (kept like your screenshot) */}
-      <section ref={heroRef} className="relative z-10 mx-auto max-w-6xl px-6 pt-6 pb-16 md:pt-10">
-        <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/70">
-          <span className="inline-flex items-center gap-1"><Rocket className="h-3.5 w-3.5 text-violet-300" /> v1.7</span>
-          <span className="text-white/40">•</span>
-          <span>New overview, brokers, settings</span>
+      <section ref={heroRef} className="relative z-10 mx-auto grid max-w-6xl gap-10 px-6 pb-16 pt-8 md:grid-cols-[1.2fr_0.8fr] md:items-center md:pb-24">
+        <div>
+          <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-white/70">
+            <span className="inline-flex items-center gap-1"><Sparkles className="h-3.5 w-3.5 text-fuchsia-300" /> Rebuilt from the original BWA</span>
+            <span className="text-white/40">•</span>
+            <span>React + GSAP + shadcn</span>
+          </div>
+          <h1 className="mt-6 text-5xl font-semibold leading-tight tracking-tight text-white md:text-6xl [font-family:var(--font-display)]">
+            Crafting trading-first web experiences with cinematic motion.
+          </h1>
+          <p className="mt-4 max-w-xl text-lg text-white/70">
+            BWA Studio blends product design, market intelligence, and kinetic storytelling to launch bold fintech experiences.
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Button asChild size="lg" className="btn-gradient">
+              <a href="#work">View Selected Work</a>
+            </Button>
+            <Button asChild size="lg" variant="outline" className="border-white/15 hover:bg-white/10">
+              <a href="#contact">Book a Call</a>
+            </Button>
+            <span className="text-xs text-white/50">Available for Q4 collaborations</span>
+          </div>
         </div>
-
-        <h1 className="mt-5 text-5xl font-semibold leading-tight tracking-tight text-white md:text-7xl">
-          Trade smarter. <span className="text-transparent bg-clip-text bg-gradient-to-r from-indigo-400 via-violet-400 to-fuchsia-400">Sleep better.</span>
-        </h1>
-        <p className="mt-5 max-w-2xl text-lg text-white/70 md:text-xl">
-          Real-time AI signals, risk controls, and execution—wrapped in a fast, secure platform designed for paper and live trading.
-        </p>
-
-        <div className="mt-8 flex flex-wrap items-center gap-3">
-          <Button asChild size="lg" className="btn-gradient">
-            <Link href="/auth">Start Free (Paper)</Link>
-          </Button>
-          <Button asChild size="lg" variant="outline" className="border-white/15 hover:bg-white/10">
-            <Link href="/overview">See the Platform</Link>
-          </Button>
-          <span className="text-xs text-white/50">No credit card • Cancel anytime</span>
-        </div>
+        <Card className="gradient-border bg-black/40 backdrop-blur">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <LineChart className="h-4 w-4 text-indigo-300" /> Live product snapshot
+            </CardTitle>
+            <CardDescription>Realtime systems, polished UI, and crisp narrative.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {[
+              { label: "Signal throughput", value: "18.2k/min" },
+              { label: "Average latency", value: "110ms" },
+              { label: "Active research modules", value: "24" },
+            ].map((item) => (
+              <div key={item.label} className="flex items-center justify-between rounded-lg border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/80">
+                <span>{item.label}</span>
+                <span className="font-semibold text-white">{item.value}</span>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
       </section>
 
-      {/* STATS (updated: keep Models & Backtests; replace others) */}
-      <section ref={statsRef} className="relative z-10 mx-auto max-w-6xl px-6">
-        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-          {[
-            { icon: <Brain className="h-4 w-4 text-indigo-300" />, k: "Models run", v: "3,142" },
-            { icon: <BarChart2 className="h-4 w-4 text-fuchsia-300" />, k: "Backtests", v: "12,870" },
-            { icon: <Signal className="h-4 w-4 text-violet-300" />, k: "Signals served", v: "8.9M" },
-            { icon: <Database className="h-4 w-4 text-sky-300" />, k: "Datasets ingested", v: "1,204" },
-          ].map(({ icon, k, v }) => (
-            <Card key={k} className="bg-black/40 backdrop-blur border-white/10">
-              <CardContent className="p-4">
-                <div className="flex items-center justify-between text-xs text-white/60">{k}{icon}</div>
-                <div className="mt-1 text-2xl font-semibold text-white">{v}</div>
+      <section ref={registerSection} className="relative z-10 mx-auto max-w-6xl px-6 pb-14" id="work">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-3xl font-semibold text-white">Selected work</h2>
+            <p className="mt-2 text-white/60">Product stories rebuilt with motion, clarity, and edge.</p>
+          </div>
+          <Button variant="outline" className="border-white/15 text-white/80 hover:bg-white/10">
+            View archive
+          </Button>
+        </div>
+        <div className="mt-8 grid gap-6 md:grid-cols-3">
+          {featuredWork.map((item) => (
+            <Card key={item.title} className="bg-black/40 backdrop-blur border-white/10">
+              <CardHeader>
+                <CardTitle>{item.title}</CardTitle>
+                <CardDescription>{item.description}</CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {item.tags.map((tag) => (
+                  <Badge key={tag} variant="outline" className="border-white/15 text-white/70">
+                    {tag}
+                  </Badge>
+                ))}
               </CardContent>
             </Card>
           ))}
         </div>
       </section>
 
-      {/* VALUE PROPS */}
-      <section ref={featuresRef} className="relative z-10 mx-auto max-w-6xl px-6 py-14">
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-          <Feature
-            icon={<LineChart className="h-5 w-5 text-indigo-300" />}
-            title="Live Market Analytics"
-            text="Tape, depth, and alerts tuned for real decisions—not noise."
-          />
-          <Feature
-            icon={<Zap className="h-5 w-5 text-fuchsia-300" />}
-            title="AI Trading Support"
-            text="Signals with confidence & rationale so you can act fast."
-          />
-          <Feature
-            icon={<Workflow className="h-5 w-5 text-violet-300" />}
-            title="Backtest → Deploy"
-            text="Walk-forward, Monte Carlo, and one-click paper/live deployment."
-          />
+      <section ref={registerSection} className="relative z-10 mx-auto max-w-6xl px-6 pb-14" id="process">
+        <div className="grid gap-6 md:grid-cols-[1fr_1.2fr]">
+          <div>
+            <h2 className="text-3xl font-semibold text-white">Build with momentum</h2>
+            <p className="mt-3 text-white/60">
+              A collaborative sprint cadence that moves from strategy to motion in weeks.
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {highlights.map((item) => (
+              <Card key={item.title} className="bg-black/40 backdrop-blur border-white/10">
+                <CardHeader className="flex-row items-start gap-3">
+                  <div className="inline-flex size-10 items-center justify-center rounded-md bg-white/5 ring-1 ring-white/10">
+                    {item.icon}
+                  </div>
+                  <div>
+                    <CardTitle className="text-white">{item.title}</CardTitle>
+                    <CardDescription className="text-white/60">{item.description}</CardDescription>
+                  </div>
+                </CardHeader>
+              </Card>
+            ))}
+          </div>
         </div>
       </section>
 
-      {/* HOW IT WORKS */}
-      <section ref={stepsRef} className="relative z-10 mx-auto max-w-6xl px-6 py-4">
-        <h3 className="text-center text-2xl font-semibold text-white">How it works</h3>
-        <p className="mt-2 text-center text-white/60">From zero to signals in minutes.</p>
-        <div className="mt-8 grid grid-cols-1 gap-5 md:grid-cols-4">
-          <Step n={1} icon={<KeyRound className="h-5 w-5" />} title="Connect" text="Authorize your brokerage securely." />
-          <Step n={2} icon={<Database className="h-5 w-5" />} title="Configure" text="Pick strategies and risk controls." />
-          <Step n={3} icon={<PlayCircle className="h-5 w-5" />} title="Backtest" text="Run realistic tests with costs and slippage." />
-          <Step n={4} icon={<Rocket2 className="h-5 w-5" />} title="Go Live" text="Deploy to paper or live instantly." />
-        </div>
-      </section>
-
-      {/* VISUAL PREVIEW */}
-      <section ref={previewRef} className="relative z-10 mx-auto max-w-6xl px-6 py-16">
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-          <Card className="gradient-border bg-black/50 backdrop-blur">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-indigo-300" /> Equity & Drawdown
-              </CardTitle>
-              <CardDescription>YTD performance (sample)</CardDescription>
-            </CardHeader>
-            <CardContent><EquityPreview /></CardContent>
-          </Card>
-
-          <Card className="gradient-border bg-black/50 backdrop-blur">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Signal className="h-4 w-4 text-fuchsia-300" /> Live Predictions
-              </CardTitle>
-              <CardDescription>Scores with confidence</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="font-mono text-sm rounded-md border border-white/10 bg-black/40 p-3 text-white/90">
-                [10:59:44] NVDA +0.22 σ • BUY (conf 0.62) • risk ok{'\n'}
-                [10:59:43] AAPL −0.10 σ • HOLD (conf 0.41){'\n'}
-                [10:59:41] MSFT +0.08 σ • HOLD (conf 0.38){'\n'}
-                [10:59:39] SPY  +0.05 σ • HOLD (conf 0.34)
-              </div>
-              <p className="mt-2 text-xs text-white/50">Wire this to your WebSocket feed for real data.</p>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-
-      {/* TRUST (generic, no broker names) */}
-      <section ref={trustRef} className="relative z-10 mx-auto max-w-6xl px-6 pb-6">
+      <section ref={registerSection} className="relative z-10 mx-auto max-w-6xl px-6 pb-16" id="stack">
         <Card className="bg-black/40 backdrop-blur border-white/10">
-          <CardContent className="p-5">
+          <CardContent className="p-6 md:p-8">
             <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-              <div className="flex items-center gap-2 text-white/80">
-                <Shield className="h-4 w-4 text-violet-300" />
-                <span className="text-sm">Security first: encrypted credentials, scoped tokens, least-privilege permissions.</span>
+              <div>
+                <h2 className="text-2xl font-semibold text-white">Stack & capability</h2>
+                <p className="text-white/60">The exact tools that powered the original BWA build.</p>
               </div>
-              <div className="flex items-center gap-3 text-xs text-white/60">
-                <span className="inline-flex items-center gap-1"><Lock className="h-3.5 w-3.5" /> Data encrypted at rest & in transit</span>
-                <span className="inline-flex items-center gap-1"><KeyRound className="h-3.5 w-3.5" /> OAuth/API-key flows</span>
-              </div>
+              <Button asChild className="btn-gradient">
+                <a href="#contact">Start a project</a>
+              </Button>
+            </div>
+            <div className="mt-6 grid gap-3 sm:grid-cols-2 md:grid-cols-3">
+              {stack.map((item) => (
+                <div key={item.label} className="flex items-center gap-3 rounded-lg border border-white/10 bg-black/40 px-4 py-3 text-sm text-white/70">
+                  <span className="text-white/80">{item.icon}</span>
+                  <span>{item.label}</span>
+                </div>
+              ))}
             </div>
           </CardContent>
         </Card>
       </section>
 
-      {/* FINAL CTA */}
-      <section ref={ctaRef} className="relative z-10 mx-auto max-w-6xl px-6 pb-20">
+      <section ref={registerSection} className="relative z-10 mx-auto max-w-6xl px-6 pb-20" id="contact">
         <Card className="bg-gradient-to-br from-indigo-500/15 via-violet-500/15 to-fuchsia-500/15 border-white/10">
           <CardContent className="p-8 md:p-10">
-            <div className="flex flex-col items-start gap-6 md:flex-row md:items-center md:justify-between">
+            <div className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
               <div>
-                <h3 className="text-2xl font-semibold text-white">Ready to trade smarter?</h3>
-                <p className="mt-1 text-white/70">Start free on paper. Upgrade to live whenever you’re ready.</p>
+                <h2 className="text-3xl font-semibold text-white">Let’s rebuild the rest.</h2>
+                <p className="mt-2 text-white/70">
+                  Share a brief, grab a slot, and we’ll rebuild the original experience with modern polish.
+                </p>
               </div>
               <div className="flex items-center gap-3">
                 <Button asChild size="lg" className="btn-gradient">
-                  <Link href="/auth">Create Account</Link>
+                  <a href="mailto:hello@bwa.studio">Email hello@bwa.studio</a>
                 </Button>
                 <Button asChild size="lg" variant="outline" className="border-white/15 hover:bg-white/10">
-                  <Link href="/overview">Explore Features</Link>
+                  <a href="#work" className="flex items-center gap-2">
+                    View work <ArrowUpRight className="h-4 w-4" />
+                  </a>
                 </Button>
               </div>
             </div>
           </CardContent>
         </Card>
-
-        <p className="mt-6 text-center text-[11px] text-white/45">
-          Trading involves risk. Past performance is not indicative of future results.
-        </p>
       </section>
 
-      {/* FOOTER */}
       <footer className="relative z-10 border-t border-white/10 bg-black/40 py-8">
         <div className="mx-auto flex max-w-6xl flex-col items-center justify-between gap-4 px-6 text-xs text-white/50 md:flex-row">
-          <div>© {new Date().getFullYear()} Jarvis StockBot</div>
+          <div>© {new Date().getFullYear()} BWA Studio</div>
           <div className="flex items-center gap-4">
-            <Link href="/settings" className="hover:text-white/80">Settings</Link>
-            <Link href="/privacy" className="hover:text-white/80">Privacy</Link>
-            <Link href="/disclosures" className="hover:text-white/80">Disclosures</Link>
+            <span>Built with React, GSAP, Tailwind, shadcn/ui</span>
           </div>
         </div>
       </footer>
-    </div>
-  );
-}
-
-/* ---------- small components ---------- */
-
-function Feature({ icon, title, text }: { icon: React.ReactNode; title: string; text: string }) {
-  return (
-    <Card className="bg-black/40 backdrop-blur border-white/10 transition-transform duration-200 hover:-translate-y-0.5 hover:shadow-[0_0_0_1px_rgba(255,255,255,.06)]">
-      <CardHeader className="flex-row items-center gap-3">
-        <div className="inline-flex size-10 items-center justify-center rounded-md bg-white/5 ring-1 ring-white/10">{icon}</div>
-        <div>
-          <CardTitle className="text-white">{title}</CardTitle>
-          <CardDescription className="text-white/60">{text}</CardDescription>
-        </div>
-      </CardHeader>
-    </Card>
-  );
-}
-
-function Step({ n, icon, title, text }: { n: number; icon: React.ReactNode; title: string; text: string }) {
-  return (
-    <Card className="bg-black/40 backdrop-blur border-white/10">
-      <CardContent className="p-5">
-        <div className="flex items-center gap-3">
-          <div className="inline-flex size-9 items-center justify-center rounded-full bg-white/5 ring-1 ring-white/10 text-white/80">{n}</div>
-          <div className="flex items-center gap-2 text-white">
-            <span className="text-white/80">{icon}</span>
-            <span className="font-medium">{title}</span>
-          </div>
-        </div>
-        <p className="mt-2 text-sm text-white/60">{text}</p>
-      </CardContent>
-    </Card>
-  );
-}
-
-function EquityPreview() {
-  return (
-    <div className="h-40 rounded-lg bg-black/40 ring-1 ring-white/10 grid place-items-center">
-      <svg viewBox="0 0 100 40" className="w-[94%] h-[80%]" style={{ color: "#7c3aed" }}>
-        <defs>
-          <linearGradient id="eq" x1="0" x2="0" y1="0" y2="1">
-            <stop offset="0%" stopColor="currentColor" stopOpacity=".5" />
-            <stop offset="100%" stopColor="currentColor" stopOpacity=".05" />
-          </linearGradient>
-        </defs>
-        <path d="M0,30 L10,28 L20,32 L30,24 L40,26 L50,18 L60,22 L70,15 L80,16 L90,8 L100,12 L100,40 L0,40 Z" fill="url(#eq)" />
-        <polyline fill="none" stroke="currentColor" strokeWidth="2" points="0,30 10,28 20,32 30,24 40,26 50,18 60,22 70,15 80,16 90,8 100,12" />
-      </svg>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Rebuild the lost BWA marketing/landing site using the existing frontend scaffold and restore the cinematic, motion-forward experience seen on the original site.  
- Provide a modular, content-first landing page that showcases work, process, stack, and contact CTAs instead of the previous StockBot marketing content.  
- Add a display font and atmospheric background visuals to match the original brand feel.  

### Description
- Replaced the landing page content in `frontend/src/app/page.tsx` with a rebuilt BWA Studio layout that adds hero, work, process, stack, and contact sections and converts GSAP animations to register sections via a `sectionRefs` pattern.  
- Updated `frontend/src/app/layout.tsx` to include the `Space_Grotesk` display font and refreshed site `metadata` to `BWA Studio`.  
- Introduced aurora background styling and animations in `frontend/src/app/globals.css` (new `@keyframes auroraDrift` and `.aurora*` styles) and adjusted blob/visual layers.  
- Removed/streamlined several StockBot-specific blocks (stats, preview components, and other small utility components) and replaced navigation and CTAs to match the BWA Studio concept.  

### Testing
- Attempted to start the dev server with `npm run dev` but it failed because the `infisical` CLI was not available, so the local dev environment did not start.  
- Attempted `npx next dev -H 0.0.0.0 -p 3000` which failed with an `npm` registry `403` error due to blocked registry access, preventing a full smoke test.  
- Source-level verification performed by running `git status`/`git commit`, and the changes were committed successfully.  
- No automated unit or integration tests were executed as part of this rollout due to the dev server and registry limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6948b870ecdc833184d91c67b4e91afb)